### PR TITLE
gzip closing before forwarding

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -74,11 +74,10 @@ class S3Output < Fluent::TimeSlicedOutput
     w = Zlib::GzipWriter.new(tmp)
     begin
       chunk.write_to(w)
-      w.finish
-      @bucket.objects[s3path].write(Pathname.new(tmp.path))
     ensure
       w.close rescue nil
     end
+    @bucket.objects[s3path].write(Pathname.new(tmp.path))
   end
 end
 


### PR DESCRIPTION
http://www.ruby-lang.org/ja/old-man/html/Zlib_GzipWriter.html

GzipWriter オブジェクトをcloseしてフッターを書き出す前に転送を始めているので、
s3でのファイルサイズが0になってしまう問題の修正です。
