### PR TITLE
loosen 'aws-sdk' version requirement

### DIFF
--- a/fluent-plugin-s3.gemspec
+++ b/fluent-plugin-s3.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "fluentd", "~> 0.10.0"
-  gem.add_dependency "aws-sdk", "~> 1.1.3"
+  gem.add_dependency "aws-sdk", "~> 1.1"
   gem.add_development_dependency "rake", ">= 0.9.2"
 end


### PR DESCRIPTION
I'm trying to use a number of aws fluent plugin at the same time.
But, the plugins have different dependencies of 'aws-sdk'.

I checkd to upload via fluent-plugin-s3 with 'aws-sdk(1.1.0)' or 'aws-sdk(1.5.3)' .Both versions worked properly.

Could you loosen 'aws-sdk' version requirement?

Testing config is as below.

```
s3_endpoint s3-ap-northeast-1.amazonaws.com
s3_bucket fluent-plugin-s3.verification
path events
buffer_path /Users/myname/tmp/s3
time_slice_format %Y%m%d/%H%M
```
