### PR TITLE
Load aws credentials from env vars or instance profile

### DIFF
--- a/fluent-plugin-s3.gemspec
+++ b/fluent-plugin-s3.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "fluentd", "~> 0.10.0"
-  gem.add_dependency "aws-sdk", "~> 1.1"
+  gem.add_dependency "aws-sdk", "~> 1.7"
   gem.add_development_dependency "rake", ">= 0.9.2"
 end

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -15,8 +15,8 @@ class S3Output < Fluent::TimeSlicedOutput
   config_param :path, :string, :default => ""
   config_param :time_format, :string, :default => nil
 
-  config_param :aws_key_id, :string
-  config_param :aws_sec_key, :string
+  config_param :aws_key_id, :string, :default => nil
+  config_param :aws_sec_key, :string, :default => nil
   config_param :s3_bucket, :string
   config_param :s3_endpoint, :string, :default => nil
 
@@ -28,10 +28,10 @@ class S3Output < Fluent::TimeSlicedOutput
 
   def start
     super
-    options = {
-      :access_key_id     => @aws_key_id,
-      :secret_access_key => @aws_sec_key
-    }
+    if @aws_key_id && @aws_sec_key
+      options[:access_key_id] = @aws_key_id
+      options[:secret_access_key] = @aws_sec_key
+    end
     options[:s3_endpoint] = @s3_endpoint if @s3_endpoint
     @s3 = AWS::S3.new(options)
     @bucket = @s3.buckets[@s3_bucket]


### PR DESCRIPTION
AWS supports loading credentials via env variables[1] and the IAM Instance Profile[2].  To achieve this you simply don't give aws any credentials.  

To enable this feature I had to make the credentials non-mandatory.  As they work as a pair I don't provide either unless they are both present.

Support for IAM Instance Role security is supported from  aws-sdk 1.5.3 [3], I've upgraded to 1.7.1 which is currently the latest.

[1] http://docs.amazonwebservices.com/AWSRubySDK/latest/AWS/Core/CredentialProviders/ENVProvider.html
[2] http://docs.amazonwebservices.com/AWSRubySDK/latest/frames.html
[3] http://aws.amazon.com/releasenotes/0304005114813505
