### PR TITLE
Set content-type when uploading to s3

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -55,7 +55,7 @@ class S3Output < Fluent::TimeSlicedOutput
     begin
       chunk.write_to(w)
       w.close
-      @bucket.objects[s3path].write(Pathname.new(tmp.path))
+      @bucket.objects[s3path].write(Pathname.new(tmp.path), :content_type => 'application/x-gzip')
     ensure
       w.close rescue nil
     end


### PR DESCRIPTION
Hello,

One of our QAs noticed that the content-type of the log archives was coming up as image/jpeg when served from s3.

I've added the correct content-type when writing the object.

PGM
