### PR TITLE
Add support for dynamic S3 paths based on Time

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -73,7 +73,7 @@ class S3Output < Fluent::TimeSlicedOutput
   def write(chunk)
     i = 0
     begin
-      parsed_path = @path.include? '%' ? Time.strftime(@path) : @path
+      parsed_path = @path.include? '%' ? Time.now.strftime(@path) : @path
       s3path = "#{parsed_path}#{chunk.key}_#{i}.gz"
       i += 1
     end while @bucket.objects[s3path].exists?


### PR DESCRIPTION
For a current project im involved in, i needed to upload logs to S3 and separate them into directories based on creation time and date (for example: year/month/day/log.json )

This commit adds support for detecting formatting strings in S3 log path, and parsing them, instead of using a static pre-defined path.

I hope you think this addition is suitable to merge into official plugin
