### PR TITLE
Close tempfile

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -110,6 +110,7 @@ class S3Output < Fluent::TimeSlicedOutput
       w.close
       @bucket.objects[s3path].write(Pathname.new(tmp.path), :content_type => 'application/x-gzip')
     ensure
+      tmp.close(true) rescue nil
       w.close rescue nil
     end
   end


### PR DESCRIPTION
A lot of temporary files were left on /tmp when the plugin couldn't write to s3 for some reason. I think it's safer to explicitly ensure a deletion, as written so in the Tempfile#Good practices ruby doc.

http://www.ruby-doc.org/stdlib-1.9.3/libdoc/tempfile/rdoc/Tempfile.html
