### PR TITLE
Added LTSV support and related configurations.

### DIFF
--- a/test/out_s3.rb
+++ b/test/out_s3.rb
@@ -194,5 +194,61 @@ class S3OutputTest < Test::Unit::TestCase
     d.run
   end
 
+  def test_output_data_type_json
+    config = [CONFIG, 'output_data_type json'].join("\n")
+    d = create_driver(config)
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    d.emit({"a"=>1, "b"=>2}, time)
+    d.emit({"a"=>2, "b"=>4}, time)
+
+    d.expect_format %[2011-01-02T13:14:15Z\ttest\t{"a":1,"b":2}\n]
+    d.expect_format %[2011-01-02T13:14:15Z\ttest\t{"a":2,"b":4}\n]
+
+    d.run
+  end
+
+  def test_output_data_type_ltsv
+    config = [CONFIG, 'output_data_type ltsv'].join("\n")
+    d = create_driver(config)
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    d.emit({"a"=>1, "b"=>2}, time)
+    d.emit({"a"=>2, "b"=>4}, time)
+
+    d.expect_format %[2011-01-02T13:14:15Z\ttest\ta:1\tb:2\n]
+    d.expect_format %[2011-01-02T13:14:15Z\ttest\ta:2\tb:4\n]
+
+    d.run
+  end
+
+  def test_output_data_type_ltsv_include_tag_and_time_true
+    config = [CONFIG, 'output_data_type ltsv', 'include_tag_and_time true'].join("\n")
+    d = create_driver(config)
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    d.emit({"a"=>1, "b"=>2}, time)
+    d.emit({"a"=>2, "b"=>4}, time)
+
+    d.expect_format %[2011-01-02T13:14:15Z\ttest\ta:1\tb:2\n]
+    d.expect_format %[2011-01-02T13:14:15Z\ttest\ta:2\tb:4\n]
+
+    d.run
+  end
+
+  def test_output_data_type_ltsv_include_tag_and_time_false
+    config = [CONFIG, 'output_data_type ltsv', 'include_tag_and_time false'].join("\n")
+    d = create_driver(config)
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    d.emit({"a"=>1, "b"=>2}, time)
+    d.emit({"a"=>2, "b"=>4}, time)
+
+    d.expect_format %[a:1\tb:2\n]
+    d.expect_format %[a:2\tb:4\n]
+
+    d.run
+  end
+
 end
 


### PR DESCRIPTION
I have added LTSV(see http://ltsv.org) support to fluent-plugin-s3.

Change point is as below:
1. Added "output_data_type" config parameter to specify how data should be output. Available value: 'json'(default) / 'ltsv'.
Note: ltsv gem is required on using 'ltsv'
2. Added "include_tag_and_time" config parameter to specify whether or not time and tag should be output separately from the data section.
Available value: true(default) / false
3. Reimplemented "format_json" support: made it behave equivalently to specifying "output_data_type json" / "include_tag_and_time false"
