### PR TITLE
support for hostname, uuid, etc. from fluent-mixin-config-placeholders

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -22,7 +22,7 @@ Simply use RubyGems:
       aws_sec_key YOUR_AWS_SECRET/KEY
       s3_bucket YOUR_S3_BUCKET_NAME
       s3_endpoint s3-ap-northeast-1.amazonaws.com
-      s3_object_key_format {path}{time_slice}_{index}.{file_extension}
+      s3_object_key_format %{path}%{time_slice}_%{index}.%{file_extension}
       path logs/
       buffer_path /var/log/fluent/s3
 
@@ -53,7 +53,7 @@ to decide keys dynamically.
 %{index} is the sequential number starts from 0, increments when multiple files are uploaded to S3 in the same time slice.
 %{file_extention} is always "gz" for now.
 
-The default format is "{path}{time_slice}_{index}.{file_extension}".
+The default format is "%{path}%{time_slice}_%{index}.%{file_extension}".
 
 For instance, using the example configuration above, actual object keys on S3 will be something like:
 
@@ -64,7 +64,7 @@ For instance, using the example configuration above, actual object keys on S3 wi
 
 With the configuration:
 
-    s3_object_key_format {path}/events/ts={time_slice}/events_{index}.{file_extension}
+    s3_object_key_format %{path}/events/ts=%{time_slice}/events_%{index}.%{file_extension}
     path log
     time_slice_format %Y%m%d-%H
 
@@ -74,6 +74,11 @@ You get:
     "log/events/ts=20130111-23/events_0.gz"
     "log/events/ts=20130111-23/events_1.gz"
     "log/events/ts=20130112-00/events_0.gz"
+
+The {fluent-mixin-config-placeholders}[https://github.com/tagomoris/fluent-mixin-config-placeholders] mixin is also incorporated, so additional variables such as %{hostname}, %{uuid}, etc. can be used in the s3_object_key_format. This could prove useful in preventing filename conflicts when writing from multiple servers.
+
+    s3_object_key_format %{path}/events/ts=%{time_slice}/events_%{index}-%{hostname}.%{file_extension}
+
 
 [path] path prefix of the files on S3. Default is "" (no prefix).
 

--- a/fluent-plugin-s3.gemspec
+++ b/fluent-plugin-s3.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "fluentd", "~> 0.10.0"
   gem.add_dependency "aws-sdk", "~> 1.7"
   gem.add_dependency "yajl-ruby", "~> 1.0"
-  gem.add_dependency "fluent-mixin-config-placeholders", "~> 0.1.0"
+  gem.add_dependency "fluent-mixin-config-placeholders", "~> 0.2.0"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "flexmock", ">= 1.2.0"
 end

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -30,9 +30,13 @@ class S3Output < Fluent::TimeSlicedOutput
   config_param :s3_endpoint, :string, :default => nil
   config_param :s3_object_key_format, :string, :default => "%{path}%{time_slice}_%{index}.%{file_extension}"
 
+  attr_reader :bucket
+
   include Fluent::Mixin::ConfigPlaceholders
 
-  attr_reader :bucket
+  def placeholders
+    [:percent]
+  end
 
   def configure(conf)
     super

--- a/test/out_s3.rb
+++ b/test/out_s3.rb
@@ -180,7 +180,7 @@ class S3OutputTest < Test::Unit::TestCase
       aws_key_id test_key_id
       aws_sec_key test_sec_key
       s3_bucket test_bucket
-      s3_object_key_format %{path}/events/ts=%{time_slice}/events_%{index}-${hostname}.%{file_extension}
+      s3_object_key_format %{path}/events/ts=%{time_slice}/events_%{index}-%{hostname}.%{file_extension}
       time_slice_format %Y%m%d-%H
       path log
       utc


### PR DESCRIPTION
This change supports additional variables from fluent-mixin-config-placeholders such as %{hostname} and %{uuid} in s3_object_key_format

<pre>
s3_object_key_format %{path}%{time_slice}_%{index}-%{hostname}.%{file_extension}
</pre>


Original thread:
https://github.com/fluent/fluent-plugin-s3/pull/16
