### PR TITLE
update aws-sdk version to refresh expiring IAM credentials

### DIFF
--- a/fluent-plugin-s3.gemspec
+++ b/fluent-plugin-s3.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "fluentd", "~> 0.10.0"
-  gem.add_dependency "aws-sdk", "~> 1.8.1.3"
+  gem.add_dependency "aws-sdk", "~> 1.8.2"
   gem.add_dependency "yajl-ruby", "~> 1.0"
   gem.add_dependency "fluent-mixin-config-placeholders", "~> 0.2.0"
   gem.add_development_dependency "rake", ">= 0.9.2"


### PR DESCRIPTION
When using IAM roles on EC2, I was getting a lot of token expiration errors when the IAM credential expired.

<pre>
2013-02-15 05:52:54 +0900: temporarily failed to flush the buffer, next retry will be at 2013-02-15 14:59:01 +0900. error="The provided token has expired." instance=70039248263400
</pre>


A newer version of the aws-sdk fixes this problem by refreshing the credentials.

ref:
https://github.com/aws/aws-sdk-ruby/blob/master/ChangeLog#L521

<pre>
  * lib/aws/core/credential_providers.rb,
  spec/aws/core/credential_providers_spec.rb: Do not cache credentials inside
  DefaultProvider as EC2Provider may
  refresh the credentials before security token is expired.
</pre>
