### PR TITLE
add dynamic path slicing by time formatted string

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -77,6 +77,17 @@ class S3Output < Fluent::TimeSlicedOutput
     end
 
     @timef = TimeFormatter.new(@time_format, @localtime)
+
+    if @localtime
+      @path_slicer = Proc.new {|path|
+        Time.now.strftime(path)
+      }
+    else
+      @path_slicer = Proc.new {|path|
+        Time.now.utc.strftime(path)
+      }
+    end
+
   end
 
   def start
@@ -121,8 +132,9 @@ class S3Output < Fluent::TimeSlicedOutput
     i = 0
 
     begin
+      path = @path_slicer.call(@path)
       values_for_s3_object_key = {
-        "path" => @path,
+        "path" => path,
         "time_slice" => chunk.key,
         "file_extension" => @ext,
         "index" => i

--- a/test/out_s3.rb
+++ b/test/out_s3.rb
@@ -70,6 +70,25 @@ class S3OutputTest < Test::Unit::TestCase
     assert(e.is_a?(Fluent::ConfigError))
   end
 
+  def test_path_slicing
+    config = CONFIG.clone.gsub(/path\slog/, "path log/%Y/%m/%d")
+    d = create_driver(config)
+    path_slicer = d.instance.instance_variable_get(:@path_slicer)
+    path = d.instance.instance_variable_get(:@path)
+    slice = path_slicer.call(path)
+    assert_equal slice, Time.now.strftime("log/%Y/%m/%d")
+  end
+
+  def test_path_slicing_utc
+    config = CONFIG.clone.gsub(/path\slog/, "path log/%Y/%m/%d")
+    config << "\nutc\n"
+    d = create_driver(config)
+    path_slicer = d.instance.instance_variable_get(:@path_slicer)
+    path = d.instance.instance_variable_get(:@path)
+    slice = path_slicer.call(path)
+    assert_equal slice, Time.now.utc.strftime("log/%Y/%m/%d")
+  end
+
   def test_format
     d = create_driver
 


### PR DESCRIPTION
This patch allows for better control over S3 paths by adding support for strftime string formats in the path configuration.

For example, providing a path `logs/%Y/%m/%d` will translate the S3 path into `logs/2013/03/20`
