### PR TITLE
Added check_apikey_on_start option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -81,6 +81,8 @@ The {fluent-mixin-config-placeholders}[https://github.com/tagomoris/fluent-mixin
 
 [auto_create_bucket] Create S3 bucket if it does not exists. Default is true.
 
+[check_apikey_on_start] Check AWS key on start. Default is true.
+
 [path] path prefix of the files on S3. Default is "" (no prefix).
 
 [buffer_path (required)] path prefix of the files to buffer logs.

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -31,6 +31,7 @@ class S3Output < Fluent::TimeSlicedOutput
   config_param :s3_object_key_format, :string, :default => "%{path}%{time_slice}_%{index}.%{file_extension}"
   config_param :store_as, :string, :default => "gzip"
   config_param :auto_create_bucket, :bool, :default => true
+  config_param :check_apikey_on_start, :bool, :default => true
   config_param :proxy_uri, :string, :default => nil
 
   attr_reader :bucket
@@ -85,7 +86,7 @@ class S3Output < Fluent::TimeSlicedOutput
     @bucket = @s3.buckets[@s3_bucket]
 
     ensure_bucket
-    check_apikeys
+    check_apikeys if @check_apikey_on_start
   end
 
   def format(tag, time, record)


### PR DESCRIPTION
Another approach to #26. It's better than #27 in terms of early checking is done by default. It allows users like me to skip checking api key on start.

I'll close #27 If this request is merged.
