### PR TITLE
Support IAM role

### DIFF
--- a/fluent-plugin-s3.gemspec
+++ b/fluent-plugin-s3.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "aws-sdk", "~> 1.8.2"
   gem.add_dependency "yajl-ruby", "~> 1.0"
   gem.add_dependency "fluent-mixin-config-placeholders", "~> 0.2.0"
-  gem.add_dependency "json", "~> 1.8"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "flexmock", ">= 1.2.0"
 end


### PR DESCRIPTION
If the box is on EC2, IAM roles should be supported. The plugin should allow passing IAM role name instead of credentials.
