### PR TITLE
Add encode_msgpack_hex option

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -52,6 +52,12 @@ class S3Output < Fluent::TimeSlicedOutput
       @format_json = false
     end
 
+    if encode_msgpack_hex = conf['encode_msgpack_hex']
+      @encode_msgpack_hex = true
+    else
+      @encode_msgpack_hex = false
+    end
+
     if use_ssl = conf['use_ssl']
       if use_ssl.empty?
         @use_ssl = true
@@ -123,6 +129,8 @@ class S3Output < Fluent::TimeSlicedOutput
 
     if @format_json
       Yajl.dump(record) + "\n"
+    elsif @encode_msgpack_hex
+      "#{time_str}\t#{tag}\t#{record.to_msgpack.unpack("H*")[0]}\n"
     else
       "#{time_str}\t#{tag}\t#{Yajl.dump(record)}\n"
     end

--- a/test/out_s3.rb
+++ b/test/out_s3.rb
@@ -172,6 +172,47 @@ class S3OutputTest < Test::Unit::TestCase
     d.run
   end
 
+  def test_format_with_encode_msgpack_hex
+    config = [CONFIG, 'encode_msgpack_hex true'].join("\n")
+    d = create_driver(config)
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    d.emit({"a"=>1}, time)
+    d.emit({"a"=>2}, time)
+
+    d.expect_format %[2011-01-02T13:14:15Z\ttest\t81a16101\n]
+    d.expect_format %[2011-01-02T13:14:15Z\ttest\t81a16102\n]
+
+    d.run
+  end
+
+  def test_format_with_encode_msgpack_hex_included_time
+    config = [CONFIG, 'encode_msgpack_hex true', 'include_time_key true'].join("\n")
+    d = create_driver(config)
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    d.emit({"a"=>1}, time)
+    d.emit({"a"=>2}, time)
+
+    d.expect_format %[2011-01-02T13:14:15Z\ttest\t82a16101a474696d65b4323031312d30312d30325431333a31343a31355a\n]
+    d.expect_format %[2011-01-02T13:14:15Z\ttest\t82a16102a474696d65b4323031312d30312d30325431333a31343a31355a\n]
+
+    d.run
+  end
+
+  def test_format_with_encode_msgpack_hex_included_tag_and_time
+    config = [CONFIG, 'encode_msgpack_hex true', 'include_tag_key true', 'include_time_key true'].join("\n")
+    d = create_driver(config)
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    d.emit({"a"=>1}, time)
+    d.emit({"a"=>2}, time)
+
+    d.expect_format %[2011-01-02T13:14:15Z\ttest\t83a16101a3746167a474657374a474696d65b4323031312d30312d30325431333a31343a31355a\n]
+    d.expect_format %[2011-01-02T13:14:15Z\ttest\t83a16102a3746167a474657374a474696d65b4323031312d30312d30325431333a31343a31355a\n]
+
+    d.run
+  end
   def test_chunk_to_write
     d = create_driver
 


### PR DESCRIPTION
Currently, I am using Hadoop Streaming with Amazon Elastic MapReduce. overhead of encode / decode the json is the bottleneck. So, I wanted a version that you want to output in binary format of msgpack that can be handled much faster.

It was mounted on the fluent-plugin-s3, in order to be able to be processed immediately without running the program the conversion process separately at the time the log is uploaded to s3.

You are output in hexadecimal, and this is because it is easier to read line by line from STDIN. I want to adopt there if there is a good format to another.
