### PR TITLE
This patch stores logs in reduced redundancy.

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -34,6 +34,7 @@ class S3Output < Fluent::TimeSlicedOutput
   config_param :auto_create_bucket, :bool, :default => true
   config_param :check_apikey_on_start, :bool, :default => true
   config_param :proxy_uri, :string, :default => nil
+  config_param :reduced_redundancy, :bool, :default => false
 
   attr_reader :bucket
 
@@ -162,7 +163,8 @@ class S3Output < Fluent::TimeSlicedOutput
         chunk.write_to(tmp)
         tmp.close
       end
-      @bucket.objects[s3path].write(Pathname.new(tmp.path), :content_type => @mime_type)
+      @bucket.objects[s3path].write(Pathname.new(tmp.path), {:content_type => @mime_type,
+                                                             :reduced_redundancy => @reduced_redundancy})
     ensure
       tmp.close(true) rescue nil
       w.close rescue nil

--- a/test/out_s3.rb
+++ b/test/out_s3.rb
@@ -230,7 +230,7 @@ class S3OutputTest < Test::Unit::TestCase
 
         pathname.to_s.match(%r|s3-|)
       },
-      {:content_type=>"application/x-gzip"})
+      {:content_type => "application/x-gzip", :reduced_redundancy => false})
 
     # Assert the key of S3Object, which event logs are stored in
     s3obj_col = flexmock(AWS::S3::ObjectCollection)
@@ -278,7 +278,7 @@ class S3OutputTest < Test::Unit::TestCase
     s3bucket, s3bucket_col = setup_mocks
 
     d = create_time_sliced_driver('auto_create_bucket false')
-    assert_raise(RuntimeError, "The specified bucket does not exist: bucket = test_bucket") { 
+    assert_raise(RuntimeError, "The specified bucket does not exist: bucket = test_bucket") {
       d.run
     }
   end
@@ -288,7 +288,7 @@ class S3OutputTest < Test::Unit::TestCase
     s3bucket_col.should_receive(:create).with_any_args.and_return { true }
 
     d = create_time_sliced_driver('auto_create_bucket true')
-    assert_nothing_raised { 
+    assert_nothing_raised {
       d.run
     }
   end


### PR DESCRIPTION
This patch uses the code of the following article :

```
http://developer.smartnews.be/blog/2013/09/02/an-effective-log-management-technique-which-uses-fluentd-and-s3/
https://github.com/moaikids/fluent-plugin-s3/commit/183708f6a9a5c2eb12e8d64a9f02233c25cb3a9d
```

For example, this feature is used and set up fluent.conf: 

```
<match pattern>
  type s3

  aws_key_id YOUR_AWS_KEY_ID
  aws_sec_key YOUR_AWS_SECRET/KEY
  s3_bucket YOUR_S3_BUCKET_NAME
  s3_endpoint s3-ap-northeast-1.amazonaws.com
  s3_object_key_format %{path}%{time_slice}_%{index}.%{file_extension}
  path logs/
  buffer_path /var/log/fluent/s3

  time_slice_format %Y%m%d-%H
  time_slice_wait 10m
  reduced_redundancy true
  utc
</match>
```

A default value of reduced_redundancy  is false.

I test the following tests:
- reduced_redundancy is true => Logs is stored in reduced redundancy.
- reduced_redundancy is false => Logs is stored in standard.
- reduced_redundancy is none => Logs is stored in standard.
