### PR TITLE
Add Snappy compression option.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -85,6 +85,7 @@ The {fluent-mixin-config-placeholders}[https://github.com/tagomoris/fluent-mixin
 - json
 - text
 - lzo (Need lzop command)
+- snappy
 
 [auto_create_bucket] Create S3 bucket if it does not exists. Default is true.
 

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -12,6 +12,7 @@ class S3Output < Fluent::TimeSlicedOutput
     require 'time'
     require 'tempfile'
     require 'open3'
+    require 'snappy'
 
     @use_ssl = true
   end
@@ -74,6 +75,7 @@ class S3Output < Fluent::TimeSlicedOutput
         end
         ['lzo', 'application/x-lzop']
       when 'json' then ['json', 'application/json']
+      when 'snappy' then ['snappy', 'application/x-snappy']
       else ['txt', 'text/plain']
     end
 
@@ -159,6 +161,9 @@ class S3Output < Fluent::TimeSlicedOutput
         tmp.close
         # We don't check the return code because we can't recover lzop failure.
         system "lzop -qf1 -o #{tmp.path} #{w.path}"
+      elsif @store_as == "snappy"
+        tmp.write(Snappy.deflate(chunk.read))
+        tmp.close
       else
         chunk.write_to(tmp)
         tmp.close

--- a/test/out_s3.rb
+++ b/test/out_s3.rb
@@ -70,6 +70,14 @@ class S3OutputTest < Test::Unit::TestCase
     assert(e.is_a?(Fluent::ConfigError))
   end
 
+  def test_configure_with_mime_type_snappy
+    conf = CONFIG.clone
+    conf << "\nstore_as snappy\n"
+    d = create_driver(conf)
+    assert_equal 'snappy', d.instance.instance_variable_get(:@ext)
+    assert_equal 'application/x-snappy', d.instance.instance_variable_get(:@mime_type)
+  end
+
   def test_path_slicing
     config = CONFIG.clone.gsub(/path\slog/, "path log/%Y/%m/%d")
     d = create_driver(config)


### PR DESCRIPTION
#6: Implement.

Install gem:
gem install snappy

Add  `store_as snappy`  in config:

``` text
<match debug.**>
  type s3

  aws_key_id YOUR_AWS_KEY_ID
  aws_sec_key YOUR_AWS_SECRET/KEY
  s3_bucket YOUR_S3_BUCKET_NAME
  s3_endpoint s3-ap-northeast-1.amazonaws.com
  s3_object_key_format %{path}%{time_slice}_%{index}.%{file_extension}
  path logs/
  buffer_path /var/log/fluent/s3

  store_as snappy   # snappy compression option

  time_slice_format %Y%m%d-%H
  time_slice_wait 10m
  utc
</match>
```

test:
22-55_0_jun-MacBook.local.snappy file in S3 is decompressed and  the decompressed text saved hoge.txt.

Input a log:

``` text
echo '{"json":"message"}' | fluent-cat debug.test
```

snappy-inflate.rb:

``` ruby
require 'snappy'

file = File.open(ARGV[0])
str = file.read
puts "str=#{str}"

str2 = Snappy.inflate(str)
puts "str2=#{str2}"

file.close

open("hoge.txt", "w") {|f| f.write str2}
```

Execute a decompressed ruby program:

``` text
ruby snappy-inflate.rb 22-55_0_jun-MacBook.local.snappy
```

hoge.txt:

``` text
2013-11-02T22:55:17+09:00   debug.test  {"json":"message"}
```
