### PR TITLE
Add optional sqs queue output

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -102,6 +102,14 @@ The {fluent-mixin-config-placeholders}[https://github.com/tagomoris/fluent-mixin
 
 [utc] Use UTC instead of local time.
 
+[sqs_queue_name] Optional, if included will send JSON message to SQS indicating file delivery to S3, formatted as:
+
+    {
+      "s3_bucket": "YOUR_S3_BUCKET_NAME",
+      "s3_path": "path/to/object"
+    }
+
+[sqs_endpoint] Optional, to specify region endpoint for optional SQS queue. Defaults to "sqs.ap-northeast-1.amazonaws.com".
 
 == Website, license, et. al.
 

--- a/test/out_s3.rb
+++ b/test/out_s3.rb
@@ -247,7 +247,6 @@ class S3OutputTest < Test::Unit::TestCase
 
     # Partial mock the S3Bucket, not to make an actual connection to Amazon S3
     s3bucket, _ = setup_mocks(true)
-
     s3bucket.should_receive(:objects).with_any_args.and_return { s3obj_col }
 
     # We must use TimeSlicedOutputTestDriver instead of BufferedOutputTestDriver,
@@ -315,11 +314,9 @@ class S3OutputTest < Test::Unit::TestCase
 
     # # Partial mock the S3Bucket, not to make an actual connection to Amazon S3
     s3bucket, _ = setup_mocks(true)
-
     s3bucket.should_receive(:objects).with_any_args.and_return { s3obj_col }
 
     sqsqueue, _ = setup_sqs_mocks
-
     sqsqueue.should_receive(:send_message).with({s3_bucket: "test_bucket", s3_path: "log/events/ts=20110102-13/events_0-testing.node.local.gz"}.to_json)
 
     d = create_time_sliced_driver('sqs_queue_name test_queue')


### PR DESCRIPTION
adds `sqs_queue_name` and `sqs_endpoint` options; if `sqs_queue_name` is specified file deliveries to S3 will also result in a message to SQS indicating the bucket and path of the file delivered. 

we wanted to have a simple way to know which S3 files have been processed downstream after fluentd drops them off to S3, this avoids having to do any sort of pipeline high-water-marking and allows our consumer to just pull files to process off of the SQS queue (without having every single event be it's own item in the queue, as is possible with https://github.com/ixixi/fluent-plugin-sqs