### PR TITLE
Problem of timing of check_apikeys?

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -114,8 +114,8 @@ class S3Output < Fluent::TimeSlicedOutput
     @s3 = AWS::S3.new(options)
     @bucket = @s3.buckets[@s3_bucket]
 
-    check_apikeys if @check_apikey_on_start
     ensure_bucket
+    check_apikeys if @check_apikey_on_start
   end
 
   def format(tag, time, record)


### PR DESCRIPTION
The following error appears.

```
2014-04-21 20:10:06 +0900 [error]: unexpected error error_class=RuntimeError error=#<RuntimeError: aws_key_id or aws_sec_key is invalid. Please check your configuration>
```
