### PR TITLE
Avoid accidental infinite loop if user misses %{index} in s3_object_key_format

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -132,8 +132,9 @@ module Fluent
 
         if s3paths_checked.include? s3path then
           raise "Invalid s3_object_key_format"
+        end
 
-        if @bucket.objects[s3path].exists?
+        if @bucket.objects[s3path].exists? then
           s3paths_checked << s3path
           i =+ 1
         else


### PR DESCRIPTION
This addresses #48 

Perhaps this is a very minor issue, but it cost me a lot so here it goes.

P.S. Apologies for the lack of style, I'm not a Ruby programmer. Had to change the loop because keeping that `begin end while` made code very unreadable with the new changes (at least to a non-Rubyist).
