### PR TITLE
Fix infinite loop when same object path is generated. fix #48

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -116,6 +116,7 @@ module Fluent
 
     def write(chunk)
       i = 0
+      previous_path = nil
 
       begin
         path = @path_slicer.call(@path)
@@ -128,7 +129,12 @@ module Fluent
         s3path = @s3_object_key_format.gsub(%r(%{[^}]+})) { |expr|
           values_for_s3_object_key[expr[2...expr.size-1]]
         }
+        if (i > 0) && (s3path == previous_path)
+          raise "duplicated path is generated. use %{index} in s3_object_key_format: path = #{s3path}"
+        end
+
         i += 1
+        previous_path = s3path
       end while @bucket.objects[s3path].exists?
 
       tmp = Tempfile.new("s3-")


### PR DESCRIPTION
S3 plugin generates unique path for avoiding path conflict.
But if users set s3_object_key_format without index,
S3 plugin tries to upload events with same path infinitely.
To fix this issue, S3 plugin raises an exception when detects same path.
If users don't use %{index}, users should set <secondary> for preventing log lost.

@jbasko Could you try this PR?
