### PR TITLE
Supports acl options

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -148,6 +148,15 @@ You can change key name by "message_key" option.
 
 [utc] Use UTC instead of local time.
 
+[acl] Permission for the object on S3. It is useful for cross-account access using IAM roles. Valid values are:
+
+- private (default)
+- public_read
+- public_read_write
+- authenticated_read
+- bucket_owner_read
+- bucket_owner_full_control
+
 == IAM Policy
 
 The following is an example for a minimal IAM policy needed to write to an s3 bucket (matches my-s3bucket/logs, my-s3bucket-test, etc.).

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -34,6 +34,7 @@ module Fluent
     config_param :proxy_uri, :string, :default => nil
     config_param :reduced_redundancy, :bool, :default => false
     config_param :format, :string, :default => 'out_file'
+    config_param :acl, :string, :default => :private
 
     attr_reader :bucket
 
@@ -163,7 +164,8 @@ module Fluent
           tmp.close
         end
         @bucket.objects[s3path].write(Pathname.new(tmp.path), {:content_type => @mime_type,
-                                                               :reduced_redundancy => @reduced_redundancy})
+                                                               :reduced_redundancy => @reduced_redundancy,
+                                                               :acl => @acl})
       ensure
         tmp.close(true) rescue nil
         w.close rescue nil

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -261,7 +261,7 @@ class S3OutputTest < Test::Unit::TestCase
 
         pathname.to_s.match(%r|s3-|)
       },
-      {:content_type => "application/x-gzip", :reduced_redundancy => false})
+      {:content_type => "application/x-gzip", :reduced_redundancy => false, :acl => :private})
 
     # Assert the key of S3Object, which event logs are stored in
     s3obj_col = flexmock(AWS::S3::ObjectCollection)


### PR DESCRIPTION
I add acl options to set permission for the object on S3.
It is useful for cross-account access using IAM roles.