### PR TITLE
Include `reduced_redundancy` in readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -148,6 +148,8 @@ You can change key name by "message_key" option.
 
 [utc] Use UTC instead of local time.
 
+[reduced_redundancy] Use S3 reduced redundancy storage for 33% cheaper pricing. Default is false.
+
 == IAM Policy
 
 The following is an example for a minimal IAM policy needed to write to an s3 bucket (matches my-s3bucket/logs, my-s3bucket-test, etc.).


### PR DESCRIPTION
I never know this option exists, and almost created issue about this feature. Luckily I searched this issue first. Maybe more people out there will prefer 33% cheaper pricing for storing log.
