### PR TITLE
Add config_param for AWS S3 Server Side Encryption

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -16,6 +16,7 @@ module Fluent
 
     config_param :path, :string, :default => ""
     config_param :use_ssl, :bool, :default => true
+    config_param :use_server_side_encryption, :string, :default => nil
     config_param :aws_key_id, :string, :default => nil
     config_param :aws_sec_key, :string, :default => nil
     config_param :s3_bucket, :string
@@ -76,6 +77,7 @@ module Fluent
       options[:region] = @s3_region if @s3_region
       options[:proxy_uri] = @proxy_uri if @proxy_uri
       options[:use_ssl] = @use_ssl
+      options[:s3_server_side_encryption] = @use_server_side_encryption
 
       @s3 = AWS::S3.new(options)
       @bucket = @s3.buckets[@s3_bucket]


### PR DESCRIPTION
Added config_param “use_server_side_encryption” to use server-side
encryption with Amazon S3-managed encryption keys

server-side encryption is not enabled by default.