### PR TITLE
Fix missing credentials error when using IAM Role

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -74,6 +74,12 @@ module Fluent
       if @aws_key_id && @aws_sec_key
         options[:access_key_id] = @aws_key_id
         options[:secret_access_key] = @aws_sec_key
+      else
+        # Avoid missing credentials error from the EC2 metadata service
+        # because of temporary loss of network connectivity when using IAM Role.
+        # This error is a rare case, so handles it in this plugin.
+        # retry retrieving credentials (wait for total approximately 2 min)
+        options[:credential_provider] = AWS::Core::CredentialProviders::EC2Provider.new({:retries => 7})
       end
       options[:region] = @s3_region if @s3_region
       options[:endpoint] = @s3_endpoint if @s3_endpoint


### PR DESCRIPTION
Missing credentials error occurs when using IAM Role.

According to AWS support, Currently the number of count to retry retrieving credentials is "0".
So I add retry setting.

Please check it.

The stacktrace is the following:

```
2015-03-20 10:34:29 +0000 [error]: failed to configure/start sub output s3: 
Missing Credentials.

Unable to find AWS credentials.  You can configure your AWS credentials
a few different ways:

* Call AWS.config with :access_key_id and :secret_access_key

* Export AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to ENV

* On EC2 you can run instances with an IAM instance profile and credentials
  will be auto loaded from the instance metadata service on those
  instances.

* Call AWS.config with :credential_provider.  A credential provider should
  either include AWS::Core::CredentialProviders::Provider or respond to
  the same public methods.

= Ruby on Rails

In a Ruby on Rails application you may also specify your credentials in
the following ways:

* Via a config initializer script using any of the methods mentioned above
  (e.g. RAILS_ROOT/config/initializers/aws-sdk.rb).

* Via a yaml configuration file located at RAILS_ROOT/config/aws.yml.
  This file should be formated like the default RAILS_ROOT/config/database.yml
  file.

2015-03-20 10:34:29 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/credential_providers.rb:140:in `credentials'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/credential_providers.rb:62:in `access_key_id'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/client.rb:549:in `build_request'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/client.rb:491:in `block (3 levels) in client_request'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/response.rb:175:in `call'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/response.rb:175:in `build_request'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/response.rb:114:in `initialize'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/client.rb:203:in `new'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/client.rb:203:in `new_response'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/client.rb:490:in `block (2 levels) in client_request'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/client.rb:391:in `log_client_request'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/client.rb:477:in `block in client_request'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/client.rb:373:in `return_or_raise'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/core/client.rb:476:in `client_request'
(eval):3:in `get_bucket_versioning'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/s3/bucket.rb:456:in `versioning_state'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/s3/bucket.rb:444:in `versioning_enabled?'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aws-sdk-v1-1.63.0/lib/aws/s3/bucket.rb:507:in `exists?'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-s3-0.5.6/lib/fluent/plugin/out_s3.rb:131:in `ensure_bucket'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-s3-0.5.6/lib/fluent/plugin/out_s3.rb:88:in `start'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-forest-0.3.0/lib/fluent/plugin/out_forest.rb:133:in `block in plant'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-forest-0.3.0/lib/fluent/plugin/out_forest.rb:128:in `synchronize'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-forest-0.3.0/lib/fluent/plugin/out_forest.rb:128:in `plant'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-forest-0.3.0/lib/fluent/plugin/out_forest.rb:168:in `emit'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/match.rb:36:in `emit'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/engine.rb:160:in `emit_stream'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/engine.rb:140:in `emit'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-add-0.0.3/lib/fluent/plugin/out_add.rb:42:in `block in emit'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/event.rb:129:in `call'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/event.rb:129:in `block in each'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/event.rb:128:in `each'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/event.rb:128:in `each'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-add-0.0.3/lib/fluent/plugin/out_add.rb:37:in `emit'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/match.rb:36:in `emit'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/engine.rb:160:in `emit_stream'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/plugin/in_tail.rb:227:in `receive_lines'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/plugin/in_tail.rb:318:in `call'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/plugin/in_tail.rb:318:in `wrap_receive_lines'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/plugin/in_tail.rb:511:in `call'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/plugin/in_tail.rb:511:in `on_notify'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/plugin/in_tail.rb:343:in `on_notify'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/plugin/in_tail.rb:444:in `call'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/plugin/in_tail.rb:444:in `on_change'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/cool.io-1.2.4/lib/cool.io/loop.rb:88:in `run_once'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/cool.io-1.2.4/lib/cool.io/loop.rb:88:in `run'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/plugin/in_tail.rb:212:in `run'
2015-03-20 10:34:29 +0000 [error]: Cannot output messages with tag 'simple_format/nat-ha.var.log.nat-ha.log'
```