### PR TITLE
Change endpoint option to s3_endpoint in S3 client configuration. fix #75

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -76,7 +76,7 @@ module Fluent
         options[:secret_access_key] = @aws_sec_key
       end
       options[:region] = @s3_region if @s3_region
-      options[:endpoint] = @s3_endpoint if @s3_endpoint
+      options[:s3_endpoint] = @s3_endpoint if @s3_endpoint
       options[:proxy_uri] = @proxy_uri if @proxy_uri
       options[:use_ssl] = @use_ssl
       options[:s3_server_side_encryption] = @use_server_side_encryption


### PR DESCRIPTION
aws-sdk-ruby now doesn't support `endpoint` option in core configuration.
So use `s3_endpoint` instead of `endpoint` is needed for s3 compatible services.