### PR TITLE
Fix usage of environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+~*
+#*
+*~
+[._]*.s[a-w][a-z]
+.DS_Store
+
+*.gem
+.bundle
+Gemfile.lock
+vendor
+.ruby-version

--- a/README.rdoc
+++ b/README.rdoc
@@ -35,6 +35,8 @@ Simply use RubyGems:
 
 [aws_sec_key] AWS secret key. This parameter is required when your agent is not running on EC2 instance with an IAM Role.
 
+[aws_iam_retries] The number of attempts to make (with exponential backoff) when loading instance profile credentials from the EC2 metadata service using an IAM role. Defaults to 5 retries.
+
 [s3_bucket (required)] S3 bucket name.
 
 [s3_region] s3 region name. For example, US West (Oregon) Region is "us-west-2". The full list of regions are available here. > http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region. We recommend using `s3_region` instead of `s3_endpoint`.

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -19,6 +19,7 @@ module Fluent
     config_param :use_server_side_encryption, :string, :default => nil
     config_param :aws_key_id, :string, :default => nil
     config_param :aws_sec_key, :string, :default => nil
+    config_param :aws_iam_retries, :integer, :default => 5
     config_param :s3_bucket, :string
     config_param :s3_region, :string, :default => nil
     config_param :s3_endpoint, :string, :default => nil
@@ -77,11 +78,7 @@ module Fluent
       elsif ENV.key? "AWS_ACCESS_KEY_ID"
         options[:credential_provider] = AWS::Core::CredentialProviders::ENVProvider.new('AWS')
       else
-        # Avoid missing credentials error from the EC2 metadata service
-        # because of temporary loss of network connectivity when using IAM Role.
-        # This error is a rare case, so handles it in this plugin.
-        # retry retrieving credentials (wait for total approximately 2 min)
-        options[:credential_provider] = AWS::Core::CredentialProviders::EC2Provider.new({:retries => 7})
+        options[:credential_provider] = AWS::Core::CredentialProviders::EC2Provider.new({:retries => @aws_iam_retries})
       end
       options[:region] = @s3_region if @s3_region
       options[:s3_endpoint] = @s3_endpoint if @s3_endpoint

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -74,6 +74,8 @@ module Fluent
       if @aws_key_id && @aws_sec_key
         options[:access_key_id] = @aws_key_id
         options[:secret_access_key] = @aws_sec_key
+      elsif ENV.key? "AWS_ACCESS_KEY_ID"
+        options[:credential_provider] = AWS::Core::CredentialProviders::ENVProvider.new('AWS')
       else
         # Avoid missing credentials error from the EC2 metadata service
         # because of temporary loss of network connectivity when using IAM Role.

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -218,7 +218,7 @@ class S3OutputTest < Test::Unit::TestCase
                  data
   end
 
-  CONFIG2 = %[
+  CONFIG_TIME_SLICE = %[
     hostname testing.node.local
     aws_key_id test_key_id
     aws_sec_key test_sec_key
@@ -228,17 +228,16 @@ class S3OutputTest < Test::Unit::TestCase
     path log
     utc
     buffer_type memory
-    auto_create_bucket false
     log_level debug
   ]
 
-  def create_time_sliced_driver(additional_conf = '')
+  def create_time_sliced_driver(conf = CONFIG_TIME_SLICE)
     d = Fluent::Test::TimeSlicedOutputTestDriver.new(Fluent::S3Output) do
       private
 
       def check_apikeys
       end
-    end.configure([CONFIG2, additional_conf].join("\n"))
+    end.configure(conf)
     d
   end
 
@@ -304,7 +303,8 @@ class S3OutputTest < Test::Unit::TestCase
   def test_auto_create_bucket_false_with_non_existence_bucket
     s3bucket, s3bucket_col = setup_mocks
 
-    d = create_time_sliced_driver('auto_create_bucket false')
+    config = CONFIG_TIME_SLICE + 'auto_create_bucket false'
+    d = create_time_sliced_driver(config)
     assert_raise(RuntimeError, "The specified bucket does not exist: bucket = test_bucket") {
       d.run
     }
@@ -314,9 +314,54 @@ class S3OutputTest < Test::Unit::TestCase
     s3bucket, s3bucket_col = setup_mocks
     s3bucket_col.should_receive(:create).with_any_args.and_return { true }
 
-    d = create_time_sliced_driver('auto_create_bucket true')
-    assert_nothing_raised {
-      d.run
-    }
+    config = CONFIG_TIME_SLICE + 'auto_create_bucket true'
+    d = create_time_sliced_driver(config)
+    assert_nothing_raised { d.run }
+  end
+
+  def test_aws_credential_provider_default
+    s3bucket, s3bucket_col = setup_mocks
+    s3bucket_col.should_receive(:create).with_any_args.and_return { true }
+
+    d = create_time_sliced_driver
+    assert_nothing_raised { d.run }
+    assert_equal "AWS::Core::CredentialProviders::DefaultProvider", d.instance.instance_variable_get(:@s3).config.credential_provider.class.to_s
+  end
+
+  def test_aws_credential_provider_env
+    s3bucket, s3bucket_col = setup_mocks
+    s3bucket_col.should_receive(:create).with_any_args.and_return { true }
+    key = ENV['AWS_ACCESS_KEY_ID']
+    ENV.replace({'AWS_ACCESS_KEY_ID' => 'my_access_key'})
+
+    config = CONFIG_TIME_SLICE.clone.split("\n").reject{|x| x =~ /.+aws_.+/}.join("\n")
+    d = create_time_sliced_driver(config)
+
+    assert_equal true, ENV.key?('AWS_ACCESS_KEY_ID')
+    assert_nothing_raised { d.run }
+    assert_equal nil, d.instance.aws_key_id
+    assert_equal nil, d.instance.aws_sec_key
+    assert_equal "AWS::Core::CredentialProviders::ENVProvider", d.instance.instance_variable_get(:@s3).config.credential_provider.class.to_s
+
+    ENV.replace({'AWS_ACCESS_KEY_ID' => key}) unless key.nil?
+  end
+
+  def test_aws_credential_provider_ec2
+    s3bucket, s3bucket_col = setup_mocks
+    s3bucket_col.should_receive(:create).with_any_args.and_return { true }
+    key = ENV['AWS_ACCESS_KEY_ID']
+    ENV.delete('AWS_ACCESS_KEY_ID')
+
+    config = CONFIG_TIME_SLICE.clone.split("\n").reject{|x| x =~ /.+aws_.+/}.join("\n")
+    d = create_time_sliced_driver(config)
+
+    assert_equal false, ENV.key?('AWS_ACCESS_KEY_ID')
+    assert_nothing_raised { d.run }
+    assert_equal nil, d.instance.aws_key_id
+    assert_equal nil, d.instance.aws_sec_key
+    assert_equal "AWS::Core::CredentialProviders::EC2Provider", d.instance.instance_variable_get(:@s3).config.credential_provider.class.to_s
+    assert_equal 7, d.instance.instance_variable_get(:@s3).config.credential_provider.retries
+
+    ENV.replace({'AWS_ACCESS_KEY_ID' => key}) unless key.nil?
   end
 end


### PR DESCRIPTION
#74 broke the usage of environment variables as configurable credentials. 

This fixes the above problem by specifying `ENVProvider`, which aligns the behavior back to the `DefaultProvider`.
http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/Core/CredentialProviders/DefaultProvider.html

Additionally, the number of retries has been made configurable with `aws_iam_retries`, defaulting to `5` based on the newer implementation of the aws sdk.
http://docs.aws.amazon.com/sdkforruby/api/Aws/InstanceProfileCredentials.html#retries-instance_method
