### PR TITLE
Added STS AssumeRole support

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -39,6 +39,10 @@ Simply use RubyGems:
 
 [aws_iam_retries] The number of attempts to make (with exponential backoff) when loading instance profile credentials from the EC2 metadata service using an IAM role. Defaults to 5 retries.
 
+[sts_role_arn] The Amazon Resource Name of an IAM role to assume. Use this to elevate permissions within your account, or to write to a bucket owned by another account.
+
+[sts_role_session_name] The Session Name to provide to Amazon when assuming an IAM role.
+
 [s3_bucket (required)] S3 bucket name.
 
 [s3_region] s3 region name. For example, US West (Oregon) Region is "us-west-2". The full list of regions are available here. > http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region. We recommend using `s3_region` instead of `s3_endpoint`.

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -90,12 +90,14 @@ module Fluent
       # Then use an AssumeRole provider when connecting to S3.
       if @sts_role_arn
         sts_conn = AWS::STS.new(options)
-        provider = AWS::Core::CredentialProviders::AssumeRoleProvider.new({
+        sts_options = {
           :sts => sts_conn,
           :role_arn => @sts_role_arn,
-          :role_session_name => @sts_role_session_name,
-          :external_id => @sts_external_id
-        })
+          :role_session_name => @sts_role_session_name
+        }
+        sts_options[:external_id] = @sts_external_id if @sts_external_id
+
+        provider = AWS::Core::CredentialProviders::AssumeRoleProvider.new(sts_options)
         options[:credential_provider] = provider
         options.delete(:access_key_id)
         options.delete(:secret_access_key)

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -22,6 +22,7 @@ module Fluent
     config_param :aws_iam_retries, :integer, :default => 5
     config_param :sts_role_arn, :string, :default => nil
     config_param :sts_role_session_name, :string, :default => nil
+    config_param :sts_external_id, :string, :default => nil
     config_param :s3_bucket, :string
     config_param :s3_region, :string, :default => nil
     config_param :s3_endpoint, :string, :default => nil
@@ -82,19 +83,26 @@ module Fluent
       else
         options[:credential_provider] = AWS::Core::CredentialProviders::EC2Provider.new({:retries => @aws_iam_retries})
       end
+      options[:proxy_uri] = @proxy_uri if @proxy_uri
+      options[:use_ssl] = @use_ssl
 
       # If a role ARN was provided, use the EC2 credential provider to connect to STS.
       # Then use an AssumeRole provider when connecting to S3.
       if @sts_role_arn
         sts_conn = AWS::STS.new(options)
-        provider = AWS::Core::CredentialProviders::AssumeRoleProvider.new({:sts => sts_conn, :role_arn => @sts_role_arn, :role_session_name => @sts_role_session_name})
+        provider = AWS::Core::CredentialProviders::AssumeRoleProvider.new({
+          :sts => sts_conn,
+          :role_arn => @sts_role_arn,
+          :role_session_name => @sts_role_session_name,
+          :external_id => @sts_external_id
+        })
         options[:credential_provider] = provider
+        options.delete(:access_key_id)
+        options.delete(:secret_access_key)
       end
 
       options[:region] = @s3_region if @s3_region
       options[:s3_endpoint] = @s3_endpoint if @s3_endpoint
-      options[:proxy_uri] = @proxy_uri if @proxy_uri
-      options[:use_ssl] = @use_ssl
       options[:s3_server_side_encryption] = @use_server_side_encryption
 
       @s3 = AWS::S3.new(options)


### PR DESCRIPTION
Added support for AssumeRole via two parameters, `sts_role_arn` and `sts_role_session_name`.

AssumeRole can be used in this case to send logs to a bucket owned by a different account. For example, development or staging accounts can forward their logs to the same account as production, allowing all logs to be consumed into the same search or reporting infrastructure.

If a role ARN is found, the plugin takes the existing credentials (IAM role, access/secret key, etc.) and creates a connection to STS, then instantiates an AssumeRole Credential Provider. This provider is passed to the S3 connection instead of the original credentials.