### PR TITLE
Support formatter plugin

### DIFF
--- a/fluent-plugin-s3.gemspec
+++ b/fluent-plugin-s3.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", [">= 0.10.49", "< 2"]
+  gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]
   gem.add_dependency "aws-sdk", "~> 2"
   gem.add_dependency "yajl-ruby", "~> 1.0"
   gem.add_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -75,9 +75,8 @@ module Fluent
       end
       @compressor.configure(conf)
 
-      # TODO: use Plugin.new_formatter instead of TextFormatter.create
-      conf['format'] = @format
-      @formatter = TextFormatter.create(conf)
+      @formatter = Plugin.new_formatter(@format)
+      @formatter.configure(conf)
 
       if @localtime
         @path_slicer = Proc.new {|path|


### PR DESCRIPTION
Make `format` option of `out_s3` accept not only `out_file` but also any other formatter plugins.