### PR TITLE
Supports acl option (rebase of #53)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -158,14 +158,17 @@ You can change key name by "message_key" option.
 
 [reduced_redundancy] Use S3 reduced redundancy storage for 33% cheaper pricing. Default is false.
 
-[acl] Permission for the object on S3. It is useful for cross-account access using IAM roles. Valid values are:
+[acl] Permission for the object in S3. This is useful for cross-account access using IAM roles. Valid values are:
 
 - private (default)
 - public_read
-- public_read_write
+- public_read_write (not recommended - see {Canned ACL}[http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl])
 - authenticated_read
 - bucket_owner_read
 - bucket_owner_full_control
+
+To use cross-account access, you will need to create a bucket policy granting
+the specific access required. Refer to the {AWS documentation}[http://docs.aws.amazon.com/AmazonS3/latest/dev/example-walkthroughs-managing-access-example3.html] for examples.
 
 == IAM Policy
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -158,6 +158,15 @@ You can change key name by "message_key" option.
 
 [reduced_redundancy] Use S3 reduced redundancy storage for 33% cheaper pricing. Default is false.
 
+[acl] Permission for the object on S3. It is useful for cross-account access using IAM roles. Valid values are:
+
+- private (default)
+- public_read
+- public_read_write
+- authenticated_read
+- bucket_owner_read
+- bucket_owner_full_control
+
 == IAM Policy
 
 The following is an example for a minimal IAM policy needed to write to an s3 bucket (matches my-s3bucket/logs, my-s3bucket-test, etc.).

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -30,6 +30,7 @@ module Fluent
     config_param :proxy_uri, :string, :default => nil
     config_param :reduced_redundancy, :bool, :default => false
     config_param :format, :string, :default => 'out_file'
+    config_param :acl, :string, :default => :private
 
     attr_reader :bucket
 
@@ -124,8 +125,31 @@ module Fluent
       tmp = Tempfile.new("s3-")
       begin
         @compressor.compress(chunk, tmp)
+        if @store_as == "gzip"
+          w = Zlib::GzipWriter.new(tmp)
+          chunk.write_to(w)
+          w.close
+        elsif @store_as == "lzo"
+          w = Tempfile.new("chunk-tmp")
+          chunk.write_to(w)
+          w.close
+          tmp.close
+          # We don't check the return code because we can't recover lzop failure.
+          system "lzop #{@command_parameter} -o #{tmp.path} #{w.path}"
+        elsif @store_as == "lzma2"
+          w = Tempfile.new("chunk-xz-tmp")
+          chunk.write_to(w)
+          w.close
+          tmp.close
+          system "xz #{@command_parameter} -c #{w.path} > #{tmp.path}"
+        else
+          chunk.write_to(tmp)
+          tmp.close
+        end
+
         @bucket.objects[s3path].write(Pathname.new(tmp.path), {:content_type => @compressor.content_type,
-                                                               :reduced_redundancy => @reduced_redundancy})
+                                                               :reduced_redundancy => @reduced_redundancy,
+                                                               :acl => @acl})
       ensure
         tmp.close(true) rescue nil
       end

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -307,7 +307,7 @@ class S3OutputTest < Test::Unit::TestCase
 
         pathname.to_s.match(%r|s3-|)
       },
-      {:content_type => "application/x-gzip", :reduced_redundancy => false})
+      {:content_type => "application/x-gzip", :reduced_redundancy => false, :acl => :private})
 
     # Assert the key of S3Object, which event logs are stored in
     s3obj_col = flexmock(AWS::S3::ObjectCollection)

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -260,7 +260,7 @@ class S3OutputTest < Test::Unit::TestCase
 
         pathname.to_s.match(%r|s3-|)
       },
-      {:content_type => "application/x-gzip", :reduced_redundancy => false})
+      {:content_type => "application/x-gzip", :reduced_redundancy => false, :acl => :private})
 
     # Assert the key of S3Object, which event logs are stored in
     s3obj_col = flexmock(AWS::S3::ObjectCollection)


### PR DESCRIPTION
This is a rebase of https://github.com/Hatayaman/fluent-plugin-s3/tree/supports_acl_option onto the current master branch. I had to fix one additional test to include the "acl" value to an S3 write hash. 

The reason for creating this separate pull request is that the original author @Hatayaman has not updated their branch since creating it.

My company has recently started using fluent to ship logs to S3, and we want to write to buckets across AWS accounts using IAM roles and bucket policies.