### PR TITLE
Allow path based calling format

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -87,6 +87,8 @@ The {fluent-mixin-config-placeholders}[https://github.com/tagomoris/fluent-mixin
 
     s3_object_key_format %{path}/events/ts=%{time_slice}/events_%{index}-%{hostname}.%{file_extension}
 
+[s3_force_path_style] :force_path_style (Boolean) — default: false — Indicates whether the generated URL should place the bucket name in the path (true) or as a subdomain (false).
+
 [store_as] archive format on S3. You can use serveral format:
 
 - gzip (default)

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -24,6 +24,7 @@ module Fluent
     config_param :s3_region, :string, :default => nil
     config_param :s3_endpoint, :string, :default => nil
     config_param :s3_object_key_format, :string, :default => "%{path}%{time_slice}_%{index}.%{file_extension}"
+    config_param :s3_force_path_style, :bool, :default => false
     config_param :store_as, :string, :default => "gzip"
     config_param :auto_create_bucket, :bool, :default => true
     config_param :check_apikey_on_start, :bool, :default => true
@@ -49,7 +50,7 @@ module Fluent
 
       begin
         @compressor = COMPRESSOR_REGISTRY.lookup(@store_as).new(:buffer_type => @buffer_type, :log => log)
-      rescue => e
+      rescue
         $log.warn "#{@store_as} not found. Use 'text' instead"
         @compressor = TextCompressor.new
       end
@@ -86,6 +87,7 @@ module Fluent
       options[:proxy_uri] = @proxy_uri if @proxy_uri
       options[:use_ssl] = @use_ssl
       options[:s3_server_side_encryption] = @use_server_side_encryption.to_sym if @use_server_side_encryption
+      options[:s3_force_path_style] = @s3_force_path_style
 
       @s3 = AWS::S3.new(options)
       @bucket = @s3.buckets[@s3_bucket]

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -44,6 +44,7 @@ class S3OutputTest < Test::Unit::TestCase
     assert d.instance.instance_variable_get(:@use_ssl)
     assert_equal 'gz', d.instance.instance_variable_get(:@compressor).ext
     assert_equal 'application/x-gzip', d.instance.instance_variable_get(:@compressor).content_type
+    assert_equal false, d.instance.s3_force_path_style
   end
 
   def test_s3_endpoint_with_valid_endpoint
@@ -74,6 +75,13 @@ class S3OutputTest < Test::Unit::TestCase
     d = create_driver(conf)
     assert_equal 'txt', d.instance.instance_variable_get(:@compressor).ext
     assert_equal 'text/plain', d.instance.instance_variable_get(:@compressor).content_type
+  end
+
+  def test_configure_with_path_style
+    conf = CONFIG.clone
+    conf << "\ns3_force_path_style true\n"
+    d = create_driver(conf)
+    assert d.instance.s3_force_path_style
   end
 
   def test_configure_with_mime_type_lzo


### PR DESCRIPTION
Some test environments might have various reasons for not supporting the subdomain calling format (it is the default calling format).  This allows enabling of the path-based calling format.