### PR TITLE
Add uuid_chunk placeholder => Change the behavior of uuid_flush placeholder to be unique for each buffer chunk

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -53,6 +53,7 @@ Simply use RubyGems:
 - %{file_extension}
 - %{uuid_flush}
 - %{hex_random}
+- %{uuid_chunk}
 
 to decide keys dynamically.
 
@@ -62,6 +63,7 @@ to decide keys dynamically.
 %{file_extention} is always "gz" for now.
 %{uuid_flush} a uuid that is replaced everytime the buffer will be flushed
 %{hex_random} a random hex string that is replaced for each buffer chunk, not assured to be unique. This is used to follow a way of peformance tuning, `Add a Hex Hash Prefix to Key Name`, written in [Request Rate and Performance Considerations - Amazon Simple Storage Service](https://docs.aws.amazon.com/AmazonS3/latest/dev/request-rate-perf-considerations.html). You can configure the length of string with a `hex_random_length` parameter (Default: 4).
+%{uuid_chunk} a uuid that is replaced for each buffer chunk, that is, not replaced on retry unlike `%{uuid_flush}`.
 
 The default format is "%{path}%{time_slice}_%{index}.%{file_extension}".
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -53,7 +53,6 @@ Simply use RubyGems:
 - %{file_extension}
 - %{uuid_flush}
 - %{hex_random}
-- %{uuid_chunk}
 
 to decide keys dynamically.
 
@@ -61,9 +60,8 @@ to decide keys dynamically.
 %{time_slice} is the time-slice in text that are formatted with *time_slice_format*.
 %{index} is the sequential number starts from 0, increments when multiple files are uploaded to S3 in the same time slice.
 %{file_extention} is always "gz" for now.
-%{uuid_flush} a uuid that is replaced everytime the buffer will be flushed
+%{uuid_flush} a uuid that is replaced for each buffer chunk to be flushed
 %{hex_random} a random hex string that is replaced for each buffer chunk, not assured to be unique. This is used to follow a way of peformance tuning, `Add a Hex Hash Prefix to Key Name`, written in [Request Rate and Performance Considerations - Amazon Simple Storage Service](https://docs.aws.amazon.com/AmazonS3/latest/dev/request-rate-perf-considerations.html). You can configure the length of string with a `hex_random_length` parameter (Default: 4).
-%{uuid_chunk} a uuid that is replaced for each buffer chunk, that is, not replaced on retry unlike `%{uuid_flush}`.
 
 The default format is "%{path}%{time_slice}_%{index}.%{file_extension}".
 

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -128,13 +128,14 @@ module Fluent
 
         @values_for_s3_object_chunk[chunk.key] ||= {
           "hex_random" => hex_random,
+          "uuid_chunk" => uuid_random,
         }
         values_for_s3_object_key = {
           "path" => path,
           "time_slice" => chunk.key,
           "file_extension" => @compressor.ext,
           "index" => i,
-          "uuid_flush" => uuid_random,
+          "uuid_flush" => uuid_random
         }.merge!(@values_for_s3_object_chunk[chunk.key])
 
         s3path = @s3_object_key_format.gsub(%r(%{[^}]+})) { |expr|

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -128,14 +128,13 @@ module Fluent
 
         @values_for_s3_object_chunk[chunk.key] ||= {
           "hex_random" => hex_random,
-          "uuid_chunk" => uuid_random,
+          "uuid_flush" => uuid_random,
         }
         values_for_s3_object_key = {
           "path" => path,
           "time_slice" => chunk.key,
           "file_extension" => @compressor.ext,
           "index" => i,
-          "uuid_flush" => uuid_random
         }.merge!(@values_for_s3_object_chunk[chunk.key])
 
         s3path = @s3_object_key_format.gsub(%r(%{[^}]+})) { |expr|


### PR DESCRIPTION
I want a uuid for each chunk, not for each flush. 

The purpose is to make it possible to detect duplications occurred by mistaken retries, which might happen if network or s3 states are terrible. 

`%{uuid_flush}` is not available for this purpose, because its uuid is changed on each flush (even on retry). 
