### PR TITLE
Add overwrite option to overwrite even if path is duplicated

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -179,6 +179,8 @@ the specific access required. Refer to the {AWS documentation}[http://docs.aws.a
 
 [hex_random_length] The length of `%{hex_random}` placeholder. Default is 4 as written in [Request Rate and Performance Considerations - Amazon Simple Storage Service](https://docs.aws.amazon.com/AmazonS3/latest/dev/request-rate-perf-considerations.html).
 
+[overwrite] Overwrite already existing path. Default is false, which raises an error if a s3 object of the same path already exists, or increment the `%{index}` placeholder until finding an absent path.
+
 === assume_role_credentials
 
 Typically, you use AssumeRole for cross-account access or federation.

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -54,6 +54,7 @@ module Fluent
     config_param :format, :string, :default => 'out_file'
     config_param :acl, :string, :default => :private
     config_param :hex_random_length, :integer, :default => 4
+    config_param :overwrite, :bool, :default => false
 
     attr_reader :bucket
 
@@ -141,7 +142,12 @@ module Fluent
           values_for_s3_object_key[expr[2...expr.size-1]]
         }
         if (i > 0) && (s3path == previous_path)
-          raise "duplicated path is generated. use %{index} in s3_object_key_format: path = #{s3path}"
+          if @overwrite
+            log.warn "#{s3path} already exists, but will overwrite"
+            break
+          else
+            raise "duplicated path is generated. use %{index} in s3_object_key_format: path = #{s3path}"
+          end
         end
 
         i += 1


### PR DESCRIPTION
My supposed use case: 

This should be useful to use together with `%{uuid_chunk}` placeholder.
`%{uuid_chunk}` placeholder assures that the path is unique for a chunk,
hence, a path duplication error occurrence means that a mistaken retry
happened. In such case, we probably can simply remove the old file by
overwriting with the new file to fix the state. 

it is difficult to write tests with mock (we can, but it will tell us nothing)

FYI: PR for `%{uuid_chunk}` is https://github.com/fluent/fluent-plugin-s3/pull/98