### PR TITLE
Allow path based calling format

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -87,6 +87,8 @@ The {fluent-mixin-config-placeholders}[https://github.com/tagomoris/fluent-mixin
 
     s3_object_key_format %{path}/events/ts=%{time_slice}/events_%{index}-%{hostname}.%{file_extension}
 
+[force_path_style] :force_path_style (Boolean) — default: false — When set to true, the bucket name is always left in the request URI and never moved to the host as a sub-domain. See Plugins::S3BucketDns for more details.
+
 [store_as] archive format on S3. You can use serveral format:
 
 - gzip (default)

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -43,6 +43,7 @@ module Fluent
     config_param :s3_region, :string, :default => ENV["AWS_REGION"] || "us-east-1"
     config_param :s3_endpoint, :string, :default => nil
     config_param :s3_object_key_format, :string, :default => "%{path}%{time_slice}_%{index}.%{file_extension}"
+    config_param :force_path_style, :bool, :default => false
     config_param :store_as, :string, :default => "gzip"
     config_param :auto_create_bucket, :bool, :default => true
     config_param :check_apikey_on_start, :bool, :default => true
@@ -69,7 +70,7 @@ module Fluent
 
       begin
         @compressor = COMPRESSOR_REGISTRY.lookup(@store_as).new(:buffer_type => @buffer_type, :log => log)
-      rescue => e
+      rescue
         $log.warn "#{@store_as} not found. Use 'text' instead"
         @compressor = TextCompressor.new
       end
@@ -132,6 +133,7 @@ module Fluent
       options[:endpoint] = @s3_endpoint if @s3_endpoint
       options[:http_proxy] = @proxy_uri if @proxy_uri
       options[:s3_server_side_encryption] = @use_server_side_encryption.to_sym if @use_server_side_encryption
+      options[:force_path_style] = @force_path_style
 
       s3_client = Aws::S3::Client.new(options)
       @s3 = Aws::S3::Resource.new(:client => s3_client)

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -44,6 +44,7 @@ class S3OutputTest < Test::Unit::TestCase
     assert_equal 'log', d.instance.path
     assert_equal 'gz', d.instance.instance_variable_get(:@compressor).ext
     assert_equal 'application/x-gzip', d.instance.instance_variable_get(:@compressor).content_type
+    assert_equal false, d.instance.force_path_style
   end
 
   def test_s3_endpoint_with_valid_endpoint
@@ -85,6 +86,13 @@ class S3OutputTest < Test::Unit::TestCase
   rescue => e
     # TODO: replace code with disable lzop command
     assert(e.is_a?(Fluent::ConfigError))
+  end
+
+  def test_configure_with_path_style
+    conf = CONFIG.clone
+    conf << "\nforce_path_style true\n"
+    d = create_driver(conf)
+    assert d.instance.force_path_style
   end
 
   def test_path_slicing


### PR DESCRIPTION
Change is now compatible with AWS v2 SDK.  Original PR was created when fluent-plugin-s3 was using v1 of the AWS SDK, which is why it passed all tests at that time, but tests later failed when fluent-plugin-s3 was switched over to AWS v2 SDK.