### PR TITLE
Keep hex random identity on rebooting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 Gemfile.lock
 vendor
 .ruby-version
+
+test/tmp/

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ ughs-managing-access-example3.html) for examples.
 The length of `%{hex_random}` placeholder. Default is 4 as written in
 [Request Rate and Performance Considerations - Amazon Simple Storage
 Service](https://docs.aws.amazon.com/AmazonS3/latest/dev/request-rate-perf-considerations.html).
+The maximum length is 16.
 
 **overwrite**
 


### PR DESCRIPTION
With https://github.com/fluent/fluent-plugin-s3/pull/96, I added `hex_random` placeholder. 
I intended that the `hex_random` values will be identical for same chunks on retrying, but I noticed that

1. `chunk.key` is not unique when data exceeds `buffer_chunk_limit` on the same time_slice. We should've used `chunk.unique_id`
2. Caching the value of `hex_random` on memory does not provide true identity for the same chunk because it is cleared on rebooting fluentd. We should've refetched from file. 

For 2, I decided to use file buffer's tsuffix which is `b5226cf8feb19f2d5` of `tmp/buf.20110102-13.b5226cf8feb19f2d5.log` for example. With this design, we do not need to create another file just to store `hex_random`. What I was disappointed was `FileBufferChunk` does not provide an API to access `tsuffix` directly, though. 

