### PR TITLE
Revert "Merge pull request #98 from sonots/uuid_chunk"

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ the sequential number starts from 0, increments when multiple files are
 uploaded to S3 in the same time slice.
 * %{file_extention} is always "gz" for
 now.
-* %{uuid_flush} a uuid that is replaced for each buffer chunk to be flushed
+* %{uuid_flush} a uuid that is replaced everytime the buffer will be flushed
 * %{hex_random} a random hex string that is replaced for each buffer chunk, not
 assured to be unique. This is used to follow a way of peformance tuning, `Add
 a Hex Hash Prefix to Key Name`, written in [Request Rate and Performance

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -133,13 +133,13 @@ module Fluent
 
         @values_for_s3_object_chunk[chunk.unique_id] ||= {
           "hex_random" => hex_random(chunk),
-          "uuid_flush" => uuid_random,
         }
         values_for_s3_object_key = {
           "path" => path,
           "time_slice" => chunk.key,
           "file_extension" => @compressor.ext,
           "index" => i,
+          "uuid_flush" => uuid_random,
         }.merge!(@values_for_s3_object_chunk[chunk.unique_id])
 
         s3path = @s3_object_key_format.gsub(%r(%{[^}]+})) { |expr|


### PR DESCRIPTION
As discussed in https://github.com/fluent/fluent-plugin-s3/pull/111,
uuid_flush can not be identical for the same chunk on restarting fluentd (the memory cache is cleared).
Let me revert.