### PR TITLE
Add ssekms_key_id option to use KMS encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,16 @@ Overwrite already existing path. Default is false, which raises an error
 if a s3 object of the same path already exists, or increment the
 `%{index}` placeholder until finding an absent path.
 
+**use_server_side_encryption**
+
+The Server-side encryption algorithm used when storing this object in S3
+(e.g., AES256, aws:kms)
+
+**ssekms_key_id**
+
+Specifies the AWS KMS key ID to use for object encryption. You have to
+set "aws:kms" to `use_server_side_encryption` to use the KMS encryption.
+
 ### assume_role_credentials
 
 Typically, you use AssumeRole for cross-account access or federation.

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -55,6 +55,7 @@ module Fluent
     config_param :acl, :string, :default => :private
     config_param :hex_random_length, :integer, :default => 4
     config_param :overwrite, :bool, :default => false
+    config_param :ssekms_key_id, :string, :default => nil
 
     attr_reader :bucket
 
@@ -167,6 +168,7 @@ module Fluent
 
         put_options = {:body => tmp, :content_type => @compressor.content_type, :storage_class => @storage_class}
         put_options[:server_side_encryption] = @use_server_side_encryption if @use_server_side_encryption
+        put_options[:ssekms_key_id] = @ssekms_key_id if @ssekms_key_id
         @bucket.object(s3path).put(put_options)
 
         @values_for_s3_object_chunk.delete(chunk.unique_id)


### PR DESCRIPTION
I added `ssekms_key_id` option to support server-side encryption by AWS KMS.
This is useful if you want to encrypt secure objects and log who used KMS key to see an object.

Using `:ssekms_key_id` option for `Aws::S3::Object#put`:
http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Object.html#put-instance_method