### PR TITLE
Add compute_checksums parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,12 @@ The Server-side encryption algorithm used when storing this object in S3
 Specifies the AWS KMS key ID to use for object encryption. You have to
 set "aws:kms" to `use_server_side_encryption` to use the KMS encryption.
 
+**compute_checksums**
+
+AWS SDK uses MD5 for API request/response by default. On FIPS enabled environment,
+OpenSSL returns an error because MD5 is disabled. If you want to use
+this plugin on FIPS enabled environment, set `compute_checksums false`.
+
 ### assume_role_credentials
 
 Typically, you use AssumeRole for cross-account access or federation.

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -56,6 +56,7 @@ module Fluent
     config_param :hex_random_length, :integer, :default => 4
     config_param :overwrite, :bool, :default => false
     config_param :ssekms_key_id, :string, :default => nil
+    config_param :compute_checksums, :bool, :default => nil # use nil to follow SDK default configuration
 
     attr_reader :bucket
 
@@ -109,6 +110,7 @@ module Fluent
       options[:endpoint] = @s3_endpoint if @s3_endpoint
       options[:http_proxy] = @proxy_uri if @proxy_uri
       options[:force_path_style] = @force_path_style
+      options[:compute_checksums] = @compute_checksums unless @compute_checksums.nil?
 
       s3_client = Aws::S3::Client.new(options)
       @s3 = Aws::S3::Resource.new(:client => s3_client)

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -49,6 +49,7 @@ class S3OutputTest < Test::Unit::TestCase
     assert_equal 'gz', d.instance.instance_variable_get(:@compressor).ext
     assert_equal 'application/x-gzip', d.instance.instance_variable_get(:@compressor).content_type
     assert_equal false, d.instance.force_path_style
+    assert_equal nil, d.instance.compute_checksums
   end
 
   def test_s3_endpoint_with_valid_endpoint
@@ -97,6 +98,13 @@ class S3OutputTest < Test::Unit::TestCase
     conf << "\nforce_path_style true\n"
     d = create_driver(conf)
     assert d.instance.force_path_style
+  end
+
+  def test_configure_with_compute_checksums
+    conf = CONFIG.clone
+    conf << "\ncompute_checksums false\n"
+    d = create_driver(conf)
+    assert_equal false, d.instance.compute_checksums
   end
 
   def test_configure_with_hex_random_length


### PR DESCRIPTION
On FIPS enabled environment, using md5 causes an error.
Set "compute_checksums false" resolves this compliant problem.

See this thread: https://groups.google.com/forum/#!topic/fluentd/OWWQIh5eQBQ