### PR TITLE
Use path as prefix when checking API keys

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -214,7 +214,7 @@ module Fluent
     end
 
     def check_apikeys
-      @bucket.objects.first
+      @bucket.objects(:prefix => @path).first
     rescue Aws::S3::Errors::NoSuchBucket
       # ignore NoSuchBucket Error because ensure_bucket checks it.
     rescue => e


### PR DESCRIPTION
Currently, [check_apikeys](https://github.com/fluent/fluent-plugin-s3/blob/b7bb960d2bb2614adcaefefdb2dd7f7f296b15f4/lib/fluent/plugin/out_s3.rb#L216) fails with tightly restricted IAM policies like as follows:

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": [
        "s3:GetBucketLocation",
        "s3:ListBucket"
      ],
      "Effect": "Allow",
      "Resource": "arn:aws:s3:::my-s3bucket",
      "Condition": {
        "StringLike": {
          "s3:prefix": "logs/*"
        }
      }
    },
    {
      "Action": [
        "s3:PutObject",
        "s3:ListObjects"
      ],
      "Resource": "arn:aws:s3:::my-s3bucket/logs/*",
      "Effect": "Allow"
    }
  ]
}
```

To solve this issue, I’ve added `:prefix` option for `Aws::S3::Bucket#objects` to `check_apikey`.
http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Bucket.html#objects-instance_method