### PR TITLE
Add 'signature_version' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ AWS SDK uses MD5 for API request/response by default. On FIPS enabled environmen
 OpenSSL returns an error because MD5 is disabled. If you want to use
 this plugin on FIPS enabled environment, set `compute_checksums false`.
 
+**signature_version**
+
+Signature version for API request. `s3` means signature version 2 and
+`v4` means signature version 4. Default is `nil` (Following SDK's default).
+It would be useful when you use S3 compatible storage that accepts only signature version 2.
+
 ### assume_role_credentials
 
 Typically, you use AssumeRole for cross-account access or federation.

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -105,6 +105,8 @@ module Fluent
     config_param :ssekms_key_id, :string, :default => nil, :secret => true
     desc "AWS SDK uses MD5 for API request/response by default"
     config_param :compute_checksums, :bool, :default => nil # use nil to follow SDK default configuration
+    desc "Signature version for API Request (s3,v4)"
+    config_param :signature_version, :string, :default => nil # use nil to follow SDK default configuration
 
     attr_reader :bucket
 
@@ -159,6 +161,7 @@ module Fluent
       options[:http_proxy] = @proxy_uri if @proxy_uri
       options[:force_path_style] = @force_path_style
       options[:compute_checksums] = @compute_checksums unless @compute_checksums.nil?
+      options[:signature_version] = @signature_version unless @signature_version.nil?
 
       s3_client = Aws::S3::Client.new(options)
       @s3 = Aws::S3::Resource.new(:client => s3_client)

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -50,6 +50,7 @@ class S3OutputTest < Test::Unit::TestCase
     assert_equal 'application/x-gzip', d.instance.instance_variable_get(:@compressor).content_type
     assert_equal false, d.instance.force_path_style
     assert_equal nil, d.instance.compute_checksums
+    assert_equal nil, d.instance.signature_version
   end
 
   def test_s3_endpoint_with_valid_endpoint
@@ -533,5 +534,13 @@ class S3OutputTest < Test::Unit::TestCase
     client = d.instance.instance_variable_get(:@s3).client
     credentials = client.config.credentials
     assert_equal(expected_credentials, credentials)
+  end
+
+  def test_signature_version
+    config = [CONFIG, 'signature_version s3'].join("\n")
+    d = create_driver(config)
+
+    signature_version = d.instance.instance_variable_get(:@signature_version)
+    assert_equal("s3", signature_version)
   end
 end


### PR DESCRIPTION
This pathch adds 'signature_version' option.
The signature version 4 is currently used for S3 API request.
However, some S3 compatible storages accept only signature version 2.
The 'signature_version' option enables users to use such a storage.