### PR TITLE
Add lz4 compressor

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ archive format on S3. You can use serveral format:
 *   text
 *   lzo (Need lzop command)
 *   lzma2 (Need xz command)
+*   lz4 (Need lz4 command)
 *   gzip_command (Need gzip command)
     *   This compressor uses an external gzip command, hence would result in
         utilizing CPU cores well compared with `gzip`

--- a/lib/fluent/plugin/s3_compressor_lz4.rb
+++ b/lib/fluent/plugin/s3_compressor_lz4.rb
@@ -1,0 +1,42 @@
+module Fluent
+  class S3Output
+    class Lz4CommandCompressor < Compressor
+      S3Output.register_compressor('lz4', self)
+
+      config_param :command_parameter, :string, :default => '-q'
+
+      def configure(conf)
+        super
+        check_command('lz4')
+      end
+
+      def ext
+        'lz4'.freeze
+      end
+
+      def content_type
+        'application/x-lz4'.freeze
+      end
+
+      def compress(chunk, tmp)
+        chunk_is_file = @buffer_type == 'file'
+        path = if chunk_is_file
+                 chunk.path
+               else
+                 w = Tempfile.new("chunk-lz4-tmp")
+                 w.binmode
+                 chunk.write_to(w)
+                 w.close
+                 w.path
+               end
+
+        # We don't check the return code because we can't recover lz4 failure.
+        system "lz4 #{@command_parameter} -c #{path} > #{tmp.path}"
+      ensure
+        unless chunk_is_file
+          w.close(true) rescue nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
lz4 is a L77-derivative that achieves better decompression speed than lzo, while achieving the same same compression speed and ratio. According to http://catchchallenger.first-world.info/wiki/Quick_Benchmark:_Gzip_vs_Bzip2_vs_LZMA_vs_XZ_vs_LZ4_vs_LZO .

I have not tested this compressor yet. Looking for early feedback. I'll say when I've tested it.