### PR TITLE
fix warn_for_delay tests for v0.14

### DIFF
--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -539,7 +539,7 @@ class S3OutputTest < Test::Unit::TestCase
     d.run
 
     logs = d.instance.log.logs
-    assert_true logs.any? {|log| log.include?('[warn]: out_s3: delayed events were put') }
+    assert_true logs.any? {|log| log.include?('out_s3: delayed events were put') }
 
     Timecop.return
     FileUtils.rm_f(s3_local_file_path)


### PR DESCRIPTION
v0.14 TestLogger currently outputs as:

```
2011-01-03 13:07:36 +0000 [warn]: [] out_s3: delayed events were put
```

This fix is just to avoid such diff.

FYI: v0.14 TestLogger tries to add optional_header like `[#{self.class.name}]`

```ruby
From: fluent/fluentd/lib/fluent/log.rb @ line 426 Fluent::PluginLoggerMixin#configure:

    422: def configure(conf)
    423:   super

    428:   if level = conf['@log_level']
    429:     unless @log.is_a?(PluginLogger)
    430:       @log = PluginLogger.new($log.dup)
    431:     end
    432:     @log.level = level
    433:     @log.optional_header = "[#{self.class.name}#{plugin_id_configured? ? "(" + @id + ")" : ""}] "
    434:     @log.optional_attrs = {}
    435:   end
    436: end
```

but, TestDriver creates plugin instance with Class.new, therefore, it does not have class name. This is reason why, we get the extra `[]` on v0.14