### PR TITLE
Support IAM role for Amazon ECS task

### DIFF
--- a/fluent-plugin-s3.gemspec
+++ b/fluent-plugin-s3.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]
-  gem.add_dependency "aws-sdk", "~> 2"
+  gem.add_dependency "aws-sdk", [">= 2.3.22", "< 3"]
   gem.add_dependency "yajl-ruby", "~> 1.0"
   gem.add_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"
   gem.add_development_dependency "rake", ">= 0.9.2"

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -312,7 +312,11 @@ module Fluent
         credentials_options[:port] = c.port if c.port
         credentials_options[:http_open_timeout] = c.http_open_timeout if c.http_open_timeout
         credentials_options[:http_read_timeout] = c.http_read_timeout if c.http_read_timeout
-        options[:credentials] = Aws::InstanceProfileCredentials.new(credentials_options)
+        if ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
+          options[:credentials] = Aws::ECSCredentials.new(credentials_options)
+        else
+          options[:credentials] = Aws::InstanceProfileCredentials.new(credentials_options)
+        end
       when @shared_credentials
         c = @shared_credentials
         credentials_options[:path] = c.path if c.path
@@ -321,7 +325,11 @@ module Fluent
       when @aws_iam_retries
         $log.warn("'aws_iam_retries' parameter is deprecated. Use 'instance_profile_credentials' instead")
         credentials_options[:retries] = @aws_iam_retries
-        options[:credentials] = Aws::InstanceProfileCredentials.new(credentials_options)
+        if ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
+          options[:credentials] = Aws::ECSCredentials.new(credentials_options)
+        else
+          options[:credentials] = Aws::InstanceProfileCredentials.new(credentials_options)
+        end
       else
         # Use default credentials
         # See http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html


### PR DESCRIPTION
`Aws::ECSCredentials` is required for using [IAM Roles for Tasks](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).

> If your container instance is using at least version 1.11.0 of the container agent and a supported version of the AWS CLI or SDKs, then the SDK client will see that the AWS_CONTAINER_CREDENTIALS_RELATIVE_URI variable is available, and it will use the provided credentials to make calls to the AWS APIs.