### PR TITLE
in: Use block style for `@parser.parse`

### DIFF
--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -218,8 +218,9 @@ module Fluent
       io = @bucket.object(key).get.body
       content = @extractor.extract(io)
       content.each_line do |line|
-        time, record = @parser.parse(line)
-        router.emit(@tag, time, record)
+        @parser.parse(line) do |time, record|
+          router.emit(@tag, time, record)
+        end
       end
     end
 

--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -217,11 +217,13 @@ module Fluent
 
       io = @bucket.object(key).get.body
       content = @extractor.extract(io)
+      es = MultiEventStream.new
       content.each_line do |line|
         @parser.parse(line) do |time, record|
-          router.emit(@tag, time, record)
+          es.add(time, record)
         end
       end
+      router.emit_stream(@tag, es)
     end
 
     class Extractor

--- a/test/test_in_s3.rb
+++ b/test/test_in_s3.rb
@@ -12,6 +12,9 @@ class S3InputTest < Test::Unit::TestCase
     Fluent::Test.setup
     @time = Time.parse("2015-09-30 13:14:15 UTC").to_i
     Fluent::Engine.now = @time
+    if Fluent.const_defined?(:EventTime)
+      stub(Fluent::EventTime).now { @time }
+    end
   end
 
   CONFIG = %[

--- a/test/test_in_s3.rb
+++ b/test/test_in_s3.rb
@@ -181,9 +181,7 @@ class S3InputTest < Test::Unit::TestCase
       [message]
     }
     assert_nothing_raised do
-      d.run do
-        d.instance.router.emit("input.s3", @time, { "message" => "aaa" })
-      end
+      d.run
     end
   end
 
@@ -221,11 +219,7 @@ class S3InputTest < Test::Unit::TestCase
       [message]
     }
     assert_nothing_raised do
-      d.run do
-        d.instance.router.emit("input.s3", @time, { "message" => "aaa\n" })
-        d.instance.router.emit("input.s3", @time, { "message" => "bbb\n" })
-        d.instance.router.emit("input.s3", @time, { "message" => "ccc\n" })
-      end
+      d.run
     end
   end
 end


### PR DESCRIPTION
Because `@parser.parse` without block style is deprecated.