### PR TITLE
Allow ignore s3 endpoint certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ recommend using `s3_region` instead of `s3_endpoint`.
 endpoint for S3 compatible services. For example, Riak CS based storage or
 something. This option doesn't work on S3, use `s3_region` instead.
 
+**ssl_verify_peer**
+
+Verify SSL certificate of the endpoint. Default is true. Set false when you want to ignore the endpoint SSL certificate.
+
 **s3_object_key_format**
 
 The format of S3 object keys. You can use several built-in variables:

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -64,6 +64,8 @@ module Fluent::Plugin
     config_param :s3_region, :string, default: ENV["AWS_REGION"] || "us-east-1"
     desc "Use 's3_region' instead"
     config_param :s3_endpoint, :string, default: nil
+    desc "If false, the certificate of endpoint will not be verified"
+    config_param :ssl_verify_peer, :bool, :default => true
     desc "The format of S3 object keys"
     config_param :s3_object_key_format, :string, default: "%{path}%{time_slice}_%{index}.%{file_extension}"
     desc "If true, the bucket name is always left in the request URI and never moved to the host as a sub-domain"
@@ -159,6 +161,7 @@ module Fluent::Plugin
       options[:force_path_style] = @force_path_style
       options[:compute_checksums] = @compute_checksums unless @compute_checksums.nil?
       options[:signature_version] = @signature_version unless @signature_version.nil?
+      options[:ssl_verify_peer] = @ssl_verify_peer
 
       s3_client = Aws::S3::Client.new(options)
       @s3 = Aws::S3::Resource.new(client: s3_client)


### PR DESCRIPTION
When we define s3 endpoint with self signed certificate, we get errors of certificate invalid.

This is useful for integration with s3 endpoints of EMC/Dell Centera S3 API.