### PR TITLE
add custom temp directory configuration for temporay file and compress.

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -10,6 +10,7 @@ module Fluent
       require 'aws-sdk-resources'
       require 'zlib'
       require 'time'
+      require 'tmpdir'
       require 'tempfile'
 
       @compressor = nil
@@ -122,6 +123,8 @@ module Fluent
     config_param :signature_version, :string, :default => nil # use nil to follow SDK default configuration
     desc "Given a threshold to treat events as delay, output warning logs if delayed events were put into s3"
     config_param :warn_for_delay, :time, :default => nil
+    desc "Custom temp dir for compressor, instead of system temp directory."
+    config_param :customer_tmp_dir, :string, :default => Dir.tmpdir
 
     attr_reader :bucket
 
@@ -253,7 +256,7 @@ module Fluent
         }
       end
 
-      tmp = Tempfile.new("s3-")
+      tmp = Tempfile.new("s3-", @customer_tmp_dir)
       tmp.binmode
       begin
         @compressor.compress(chunk, tmp)

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -10,7 +10,6 @@ module Fluent
       require 'aws-sdk-resources'
       require 'zlib'
       require 'time'
-      require 'tmpdir'
       require 'tempfile'
 
       @compressor = nil
@@ -123,8 +122,8 @@ module Fluent
     config_param :signature_version, :string, :default => nil # use nil to follow SDK default configuration
     desc "Given a threshold to treat events as delay, output warning logs if delayed events were put into s3"
     config_param :warn_for_delay, :time, :default => nil
-    desc "Custom temp dir for compressor, instead of system temp directory."
-    config_param :customer_tmp_dir, :string, :default => Dir.tmpdir
+    desc "Custom temporary dir for temporary files, instead of system temp directory."
+    config_param :customer_tmp_dir, :string, :default => nil
 
     attr_reader :bucket
 
@@ -405,6 +404,8 @@ module Fluent
 
     class Compressor
       include Configurable
+
+      config_param :customer_tmp_dir, :string, :default => nil
 
       def initialize(opts = {})
         super()

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -122,8 +122,8 @@ module Fluent
     config_param :signature_version, :string, :default => nil # use nil to follow SDK default configuration
     desc "Given a threshold to treat events as delay, output warning logs if delayed events were put into s3"
     config_param :warn_for_delay, :time, :default => nil
-    desc "Custom temporary dir for temporary files, instead of system temp directory."
-    config_param :customer_tmp_dir, :string, :default => nil
+    desc "Directory for temporary files, instead of system temp directory."
+    config_param :tmp_dir, :string, :default => nil
 
     attr_reader :bucket
 
@@ -255,7 +255,7 @@ module Fluent
         }
       end
 
-      tmp = Tempfile.new("s3-", @customer_tmp_dir)
+      tmp = Tempfile.new("s3-", @tmp_dir)
       tmp.binmode
       begin
         @compressor.compress(chunk, tmp)
@@ -405,7 +405,7 @@ module Fluent
     class Compressor
       include Configurable
 
-      config_param :customer_tmp_dir, :string, :default => nil
+      config_param :tmp_dir, :string, :default => nil
 
       def initialize(opts = {})
         super()

--- a/lib/fluent/plugin/s3_compressor_gzip_command.rb
+++ b/lib/fluent/plugin/s3_compressor_gzip_command.rb
@@ -23,7 +23,7 @@ module Fluent
         path = if chunk_is_file
                  chunk.path
                else
-                 w = Tempfile.new("chunk-gzip-tmp", @customer_tmp_dir)
+                 w = Tempfile.new("chunk-gzip-tmp", @tmp_dir)
                  w.binmode
                  chunk.write_to(w)
                  w.close

--- a/lib/fluent/plugin/s3_compressor_gzip_command.rb
+++ b/lib/fluent/plugin/s3_compressor_gzip_command.rb
@@ -4,6 +4,7 @@ module Fluent
       S3Output.register_compressor('gzip_command', self)
 
       config_param :command_parameter, :string, :default => ''
+      config_param :customer_tmp_dir, :string, :default => Dir.tmpdir
 
       def configure(conf)
         super

--- a/lib/fluent/plugin/s3_compressor_gzip_command.rb
+++ b/lib/fluent/plugin/s3_compressor_gzip_command.rb
@@ -4,7 +4,6 @@ module Fluent
       S3Output.register_compressor('gzip_command', self)
 
       config_param :command_parameter, :string, :default => ''
-      config_param :customer_tmp_dir, :string, :default => Dir.tmpdir
 
       def configure(conf)
         super

--- a/lib/fluent/plugin/s3_compressor_gzip_command.rb
+++ b/lib/fluent/plugin/s3_compressor_gzip_command.rb
@@ -23,7 +23,7 @@ module Fluent
         path = if chunk_is_file
                  chunk.path
                else
-                 w = Tempfile.new("chunk-gzip-tmp")
+                 w = Tempfile.new("chunk-gzip-tmp", @customer_tmp_dir)
                  w.binmode
                  chunk.write_to(w)
                  w.close

--- a/lib/fluent/plugin/s3_compressor_lzma2.rb
+++ b/lib/fluent/plugin/s3_compressor_lzma2.rb
@@ -19,7 +19,7 @@ module Fluent
       end
 
       def compress(chunk, tmp)
-        w = Tempfile.new("chunk-xz-tmp", @customer_tmp_dir)
+        w = Tempfile.new("chunk-xz-tmp", @tmp_dir)
         w.binmode
         chunk.write_to(w)
         w.close

--- a/lib/fluent/plugin/s3_compressor_lzma2.rb
+++ b/lib/fluent/plugin/s3_compressor_lzma2.rb
@@ -4,7 +4,6 @@ module Fluent
       S3Output.register_compressor('lzma2', self)
 
       config_param :command_parameter, :string, :default => '-qf0'
-      config_param :customer_tmp_dir, :string, :default => Dir.tmpdir
 
       def configure(conf)
         super

--- a/lib/fluent/plugin/s3_compressor_lzma2.rb
+++ b/lib/fluent/plugin/s3_compressor_lzma2.rb
@@ -4,6 +4,7 @@ module Fluent
       S3Output.register_compressor('lzma2', self)
 
       config_param :command_parameter, :string, :default => '-qf0'
+      config_param :customer_tmp_dir, :string, :default => Dir.tmpdir
 
       def configure(conf)
         super

--- a/lib/fluent/plugin/s3_compressor_lzma2.rb
+++ b/lib/fluent/plugin/s3_compressor_lzma2.rb
@@ -19,7 +19,7 @@ module Fluent
       end
 
       def compress(chunk, tmp)
-        w = Tempfile.new("chunk-xz-tmp")
+        w = Tempfile.new("chunk-xz-tmp", @customer_tmp_dir)
         w.binmode
         chunk.write_to(w)
         w.close

--- a/lib/fluent/plugin/s3_compressor_lzo.rb
+++ b/lib/fluent/plugin/s3_compressor_lzo.rb
@@ -19,7 +19,7 @@ module Fluent
       end
 
       def compress(chunk, tmp)
-        w = Tempfile.new("chunk-tmp")
+        w = Tempfile.new("chunk-tmp", @customer_tmp_dir)
         w.binmode
         chunk.write_to(w)
         w.close

--- a/lib/fluent/plugin/s3_compressor_lzo.rb
+++ b/lib/fluent/plugin/s3_compressor_lzo.rb
@@ -19,7 +19,7 @@ module Fluent
       end
 
       def compress(chunk, tmp)
-        w = Tempfile.new("chunk-tmp", @customer_tmp_dir)
+        w = Tempfile.new("chunk-tmp", @tmp_dir)
         w.binmode
         chunk.write_to(w)
         w.close

--- a/lib/fluent/plugin/s3_compressor_lzo.rb
+++ b/lib/fluent/plugin/s3_compressor_lzo.rb
@@ -4,7 +4,6 @@ module Fluent
       S3Output.register_compressor('lzo', self)
 
       config_param :command_parameter, :string, :default => '-qf1'
-      config_param :customer_tmp_dir, :string, :default => Dir.tmpdir
 
       def configure(conf)
         super

--- a/lib/fluent/plugin/s3_compressor_lzo.rb
+++ b/lib/fluent/plugin/s3_compressor_lzo.rb
@@ -4,6 +4,7 @@ module Fluent
       S3Output.register_compressor('lzo', self)
 
       config_param :command_parameter, :string, :default => '-qf1'
+      config_param :customer_tmp_dir, :string, :default => Dir.tmpdir
 
       def configure(conf)
         super

--- a/lib/fluent/plugin/s3_extractor_lzo.rb
+++ b/lib/fluent/plugin/s3_extractor_lzo.rb
@@ -4,6 +4,7 @@ module Fluent
       S3Input.register_extractor('lzo', self)
 
       config_param :command_parameter, :string, :default => '-qdc'
+      config_param :customer_tmp_dir, :string, :default => Dir.tmpdir
 
       def configure(conf)
         super

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -452,7 +452,7 @@ EOC
     s3obj.exists? { false }
 
     tempfile = File.new(s3_local_file_path, "w")
-    stub(Tempfile).new("s3-") { tempfile }
+    stub(Tempfile).new("s3-", nil) { tempfile }
     s3obj.put(:body => tempfile,
               :content_type => "application/x-gzip",
               :storage_class => "STANDARD")
@@ -484,7 +484,7 @@ EOC
                                      :client => @s3_client))
 
     tempfile = File.new(s3_local_file_path, "w")
-    stub(Tempfile).new("s3-") { tempfile }
+    stub(Tempfile).new("s3-", nil) { tempfile }
     s3obj.put(:body => tempfile,
               :content_type => "application/x-gzip",
               :storage_class => "STANDARD")


### PR DESCRIPTION
Few days ago, I got warn log:
```
2017-03-28 00:06:38 -0700 [warn]: temporarily failed to flush the buffer. next_retry=2017-03-28 00:05:37 -0700 error_class="Errno::ENOSPC" error="No space left on device - w
rite" plugin_id="object:3ff24b19ccc4"
  2017-03-28 00:06:38 -0700 [warn]: /opt/td-agent/embedded/lib/ruby/2.1.0/fileutils.rb:494:in `copy_stream'
  2017-03-28 00:06:38 -0700 [warn]: /opt/td-agent/embedded/lib/ruby/2.1.0/fileutils.rb:494:in `copy_stream'
  2017-03-28 00:06:38 -0700 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.12/lib/fluent/buffer.rb:109:in `block in write_to'
  2017-03-28 00:06:38 -0700 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.12/lib/fluent/plugin/buf_file.rb:64:in `open'
  2017-03-28 00:06:38 -0700 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.12/lib/fluent/buffer.rb:108:in `write_to'
  2017-03-28 00:06:38 -0700 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-s3-0.5.9/lib/fluent/plugin/s3_compressor_lzo.rb:23:in `compress'
  2017-03-28 00:06:38 -0700 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-s3-0.5.9/lib/fluent/plugin/out_s3.rb:125:in `write'
  2017-03-28 00:06:38 -0700 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.12/lib/fluent/buffer.rb:325:in `write_chunk'
  2017-03-28 00:06:38 -0700 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.12/lib/fluent/buffer.rb:304:in `pop'
  2017-03-28 00:06:38 -0700 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.12/lib/fluent/output.rb:321:in `try_flush'
  2017-03-28 00:06:38 -0700 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.12/lib/fluent/output.rb:140:in `run'
2017-03-28 00:07:39 -0700 [warn]: retry succeeded. plugin_id="object:3ff24b19ccc4"
```

The `lzo` file in s3 is incomplete and failed when decompress.

I found the plugin will save buffer(1g in my case) to `/tmp`, and then compress to file(eg, lzo) in `/tmp`, when flush lots of tags at same time, the temp files will cost more than 7GB, run out of space of root, and will not check compress failure.
```
        # We don't check the return code because we can't recover lzop failure.
        system "lzop #{@command_parameter} -o #{tmp.path} #{w.path}"
```

So I add custom directory setting which instead of using default system temp directory, to make sure have enough space for save temp file and compress file .

