### PR TITLE
URI unescape S3 key

### DIFF
--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -5,6 +5,7 @@ require 'aws-sdk-resources'
 require 'zlib'
 require 'time'
 require 'tempfile'
+require 'uri'
 
 module Fluent::Plugin
   class S3Input < Input
@@ -218,7 +219,7 @@ module Fluent::Plugin
 
     def process(body)
       s3 = body["Records"].first["s3"]
-      key = s3["object"]["key"]
+      key = URI.unescape(s3["object"]["key"])
 
       io = @bucket.object(key).get.body
       content = @extractor.extract(io)


### PR DESCRIPTION
From http://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html:

> The s3 key provides information about the bucket and object involved in the event. Note that the object keyname value is URL encoded. For example "red flower.jpg" becomes "red+flower.jpg".