### PR TITLE
Add use_bundled_cert parameter to use ruby-sdk-ruby bundled cert

### DIFF
--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -20,6 +20,8 @@ module Fluent::Plugin
 
     DEFAULT_PARSE_TYPE = "none"
 
+    desc "Use aws-sdk-ruby bundled cert"
+    config_param :use_bundled_cert, :bool, default: false
     desc "AWS access key id"
     config_param :aws_key_id, :string, default: nil, secret: true
     desc "AWS secret key."
@@ -92,6 +94,8 @@ module Fluent::Plugin
       unless @sqs.queue_name
         raise Fluent::ConfigError, "sqs/queue_name is required"
       end
+
+      Aws.use_bundled_cert! if @use_bundled_cert
 
       @extractor = EXTRACTOR_REGISTRY.lookup(@store_as).new(log: log)
       @extractor.configure(conf)

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -22,6 +22,8 @@ module Fluent::Plugin
     config_param :path, :string, default: ""
     desc "The Server-side encryption algorithm used when storing this object in S3 (AES256, aws:kms)"
     config_param :use_server_side_encryption, :string, default: nil
+    desc "Use aws-sdk-ruby bundled cert"
+    config_param :use_bundled_cert, :bool, default: false
     desc "AWS access key id"
     config_param :aws_key_id, :string, default: nil, secret: true
     desc "AWS secret key."
@@ -128,6 +130,8 @@ module Fluent::Plugin
       compat_parameters_convert(conf, :buffer, :formatter, :inject)
 
       super
+
+      Aws.use_bundled_cert! if @use_bundled_cert
 
       if @s3_endpoint && @s3_endpoint.end_with?('amazonaws.com')
         raise Fluent::ConfigError, "s3_endpoint parameter is not supported for S3, use s3_region instead. This parameter is for S3 compatible services"


### PR DESCRIPTION
If the OS / middleware provided cert has a problem with AWS API, need to use bundled cert instead.