### PR TITLE
Fix s3 logging

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -268,7 +268,7 @@ module Fluent::Plugin
       begin
         @compressor.compress(chunk, tmp)
         tmp.rewind
-        log.debug "out_s3: write chunk: {key:#{chunk.key},tsuffix:#{tsuffix(chunk)}} to s3://#{@s3_bucket}/#{s3path}"
+        log.debug "out_s3: write chunk: {unique_id:#{chunk.unique_id},tsuffix:#{tsuffix(chunk)}} to s3://#{@s3_bucket}/#{s3path}"
 
         put_options = {
           body: tmp,

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -268,7 +268,7 @@ module Fluent::Plugin
       begin
         @compressor.compress(chunk, tmp)
         tmp.rewind
-        log.debug "out_s3: write chunk: {unique_id:#{chunk.unique_id},tsuffix:#{tsuffix(chunk)}} to s3://#{@s3_bucket}/#{s3path}"
+        log.debug "out_s3: write chunk with metadata #{chunk.metadata} to s3://#{@s3_bucket}/#{s3path}"
 
         put_options = {
           body: tmp,

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -268,7 +268,7 @@ module Fluent::Plugin
       begin
         @compressor.compress(chunk, tmp)
         tmp.rewind
-        log.debug { "out_s3: write chunk: {key:#{chunk.key},tsuffix:#{tsuffix(chunk)}} to s3://#{@s3_bucket}/#{s3path}" }
+        log.debug "out_s3: write chunk: {key:#{chunk.key},tsuffix:#{tsuffix(chunk)}} to s3://#{@s3_bucket}/#{s3path}"
 
         put_options = {
           body: tmp,
@@ -294,7 +294,7 @@ module Fluent::Plugin
 
         if @warn_for_delay
           if Time.at(chunk.metadata.timekey) < Time.now - @warn_for_delay
-            log.warn { "out_s3: delayed events were put to s3://#{@s3_bucket}/#{s3path}" }
+            log.warn "out_s3: delayed events were put to s3://#{@s3_bucket}/#{s3path}"
           end
         end
       ensure


### PR DESCRIPTION
- Wrapping the log statement in `{ }` was causing it not to actually be logged
- `chunk.key` and `tsuffix()` don't seem to exist