### PR TITLE
[v0.14] Support for granting a permission to a canonical user id

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,35 @@ To use cross-account access, you will need to create a bucket policy granting
 the specific access required. Refer to the [AWS
 documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/example-walkthroughs-managing-access-example3.html) for examples.
 
+**grant_full_control**
+
+Allows grantee READ, READ_ACP, and WRITE_ACP permissions on the object.
+This is useful for cross-account access using IAM roles.
+
+Valid values are `id="Grantee-CanonicalUserID"`. Please specify the grantee's canonical user ID.
+e.g. id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"
+
+Note that a canonical user ID is different from an AWS account ID.
+Please refer to [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html) for more details.
+
+**grant_read**
+
+Allows grantee to read the object data and its metadata.
+Valid values are `id="Grantee-CanonicalUserID"`. Please specify the grantee's canonical user ID.
+e.g. id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"
+
+**grant_read_acp**
+
+Allows grantee to read the object ACL.
+Valid values are `id="Grantee-CanonicalUserID"`. Please specify the grantee's canonical user ID.
+e.g. id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"
+
+**grant_write_acp**
+
+Allows grantee to write the ACL for the applicable object.
+Valid values are `id="Grantee-CanonicalUserID"`. Please specify the grantee's canonical user ID.
+e.g. id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"
+
 **hex_random_length**
 
 The length of `%{hex_random}` placeholder. Default is 4 as written in

--- a/README.md
+++ b/README.md
@@ -372,7 +372,8 @@ Allows grantee READ, READ_ACP, and WRITE_ACP permissions on the object.
 This is useful for cross-account access using IAM roles.
 
 Valid values are `id="Grantee-CanonicalUserID"`. Please specify the grantee's canonical user ID.
-e.g. id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"
+
+e.g. `id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"`
 
 Note that a canonical user ID is different from an AWS account ID.
 Please refer to [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html) for more details.
@@ -381,19 +382,22 @@ Please refer to [AWS documentation](https://docs.aws.amazon.com/general/latest/g
 
 Allows grantee to read the object data and its metadata.
 Valid values are `id="Grantee-CanonicalUserID"`. Please specify the grantee's canonical user ID.
-e.g. id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"
+
+e.g. `id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"`
 
 **grant_read_acp**
 
 Allows grantee to read the object ACL.
 Valid values are `id="Grantee-CanonicalUserID"`. Please specify the grantee's canonical user ID.
-e.g. id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"
+
+e.g. `id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"`
 
 **grant_write_acp**
 
 Allows grantee to write the ACL for the applicable object.
 Valid values are `id="Grantee-CanonicalUserID"`. Please specify the grantee's canonical user ID.
-e.g. id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"
+
+e.g. `id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"`
 
 **hex_random_length**
 

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -88,6 +88,14 @@ module Fluent::Plugin
     config_param :storage_class, :string, default: "STANDARD"
     desc "Permission for the object in S3"
     config_param :acl, :string, default: nil
+    desc "Allows grantee READ, READ_ACP, and WRITE_ACP permissions on the object"
+    config_param :grant_full_control, :string, default: nil
+    desc "Allows grantee to read the object data and its metadata"
+    config_param :grant_read, :string, default: nil
+    desc "Allows grantee to read the object ACL"
+    config_param :grant_read_acp, :string, default: nil
+    desc "Allows grantee to write the ACL for the applicable object"
+    config_param :grant_write_acp, :string, default: nil
     desc "The length of `%{hex_random}` placeholder(4-16)"
     config_param :hex_random_length, :integer, default: 4
     desc "Overwrite already existing path"
@@ -286,6 +294,10 @@ module Fluent::Plugin
         put_options[:sse_customer_key] = @sse_customer_key if @sse_customer_key
         put_options[:sse_customer_key_md5] = @sse_customer_key_md5 if @sse_customer_key_md5
         put_options[:acl] = @acl if @acl
+        put_options[:grant_full_control] = @grant_full_control if @grant_full_control
+        put_options[:grant_read] = @grant_read if @grant_read
+        put_options[:grant_read_acp] = @grant_read_acp if @grant_read_acp
+        put_options[:grant_write_acp] = @grant_write_acp if @grant_write_acp
 
         if @s3_metadata
           put_options[:metadata] = {}

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -140,6 +140,16 @@ class S3OutputTest < Test::Unit::TestCase
     assert_equal false, d.instance.check_object
   end
 
+  def test_configure_with_grant
+    conf = CONFIG.clone
+    conf << "\grant_full_control id='0123456789'\ngrant_read id='1234567890'\ngrant_read_acp id='2345678901'\ngrant_write_acp id='3456789012'\n"
+    d = create_driver(conf)
+    assert_equal "id='0123456789'", d.instance.grant_full_control
+    assert_equal "id='1234567890'", d.instance.grant_read
+    assert_equal "id='2345678901'", d.instance.grant_read_acp
+    assert_equal "id='3456789012'", d.instance.grant_write_acp
+  end
+
   def test_format
     d = create_driver
 


### PR DESCRIPTION
Fixes #212 
This is for fluentd v.0.14. The same changes as #213 