### PR TITLE
Fix minimal iam policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,7 +666,8 @@ bucket (matches my-s3bucket/logs, my-s3bucket-test, etc.).
         {
           "Effect": "Allow",
           "Action": [
-            "s3:PutObject"
+            "s3:PutObject",
+			"s3:GetObject"
           ],
           "Resource": "arn:aws:s3:::my-s3bucket/*"
         }

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ bucket (matches my-s3bucket/logs, my-s3bucket-test, etc.).
           "Effect": "Allow",
           "Action": [
             "s3:PutObject",
-			"s3:GetObject"
+            "s3:GetObject"
           ],
           "Resource": "arn:aws:s3:::my-s3bucket/*"
         }


### PR DESCRIPTION
# Background

When fluent-plugin-s3 writes file to s3, the plugin calls `Object#wait_until_exists` and `Client#head_object` of AWS sdk if `check_object` is configured as `true` (default).  `Client#head_object` requires [s3:GetObject](http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html) permission, but minimal IAM policy example does not have `s3:GetObject`. Then, fluent-plugin-s3 fails an operation to put a file into s3 with default value of `check_object` and the minimal IAM policy example.

I know the IAM Policy including `s3:GetObject` for fluent-plugin-s3 is not "minimal" because user can disable `check_object`. But I'm thinking that many beginners like me may be in trouble. 

# Changes

Added `s3:GetObject` permission to minimal IAM Policy example in README.md