### PR TITLE
in_s3: Add bucket and object key to parsed records

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,11 +593,16 @@ Given a threshold to treat events as delay, output warning logs if delayed event
       aws_sec_key YOUR_AWS_SECRET_KEY
       s3_bucket YOUR_S3_BUCKET_NAME
       s3_region ap-northeast-1
+      add_object_metadata true
 
       <sqs>
         queue_name YOUR_SQS_QUEUE_NAME
       </sqs>
     </source>
+
+**add_object_metadata**
+
+Whether or not object metadata should be added to the record. Defaults to `false`. See below for details.
 
 **s3_bucket (required)**
 
@@ -656,10 +661,10 @@ Interval to retry polling SQS if polling unsuccessful, in seconds. Default is 30
 
 ## Object Metadata Added To Records
 
-The name of the bucket and the key for a given object will be added to each log 
-record as `s3_bucket` and `s3_key`, respectively. This metadata can be used by
-filter plugins or other downstream processors to better identify the source of a
-given record.
+If the `add_object_metadata` option is set to true, then the name of the bucket
+and the key for a given object will be added to each log record as `s3_bucket`
+and `s3_key`, respectively. This metadata can be used by filter plugins or other
+downstream processors to better identify the source of a given record.
 
 ## IAM Policy
 

--- a/README.md
+++ b/README.md
@@ -654,6 +654,13 @@ The long polling interval. Default is 20.
 
 Interval to retry polling SQS if polling unsuccessful, in seconds. Default is 300.
 
+## Object Metadata Added To Records
+
+The name of the bucket and the key for a given object will be added to each log 
+record as `s3_bucket` and `s3_key`, respectively. This metadata can be used by
+filter plugins or other downstream processors to better identify the source of a
+given record.
+
 ## IAM Policy
 
 The following is an example for a minimal IAM policy needed to write to an s3

--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -24,6 +24,8 @@ module Fluent::Plugin
 
     desc "Use aws-sdk-ruby bundled cert"
     config_param :use_bundled_cert, :bool, default: false
+    desc "Add object metadata to the records parsed out of a given object"
+    config_param :add_object_metadata, :bool, default: false
     desc "AWS access key id"
     config_param :aws_key_id, :string, default: nil, secret: true
     desc "AWS secret key."
@@ -264,8 +266,10 @@ module Fluent::Plugin
       es = Fluent::MultiEventStream.new
       content.each_line do |line|
         @parser.parse(line) do |time, record|
-          record['s3_bucket'] = @s3_bucket
-          record['s3_key'] = raw_key
+          if @add_object_metadata
+            record['s3_bucket'] = @s3_bucket
+            record['s3_key'] = raw_key
+          end
           es.add(time, record)
         end
       end

--- a/test/test_in_s3.rb
+++ b/test/test_in_s3.rb
@@ -221,7 +221,7 @@ EOS
     end
     d.run(expect_emits: 1)
     events = d.events
-    assert_equal({ "message" => "aaa" }, events.first[2])
+    assert_equal({ "s3_bucket" => "test_bucket", "s3_key" => "test_key", "message" => "aaa" }, events.first[2])
   end
 
   def test_one_record_url_encoded
@@ -256,7 +256,7 @@ EOS
     end
     d.run(expect_emits: 1)
     events = d.events
-    assert_equal({ "message" => "aaa" }, events.first[2])
+    assert_equal({ "s3_bucket" => "test_bucket", "s3_key" => "test+key", "message" => "aaa" }, events.first[2])
   end
 
   def test_one_record_multi_line
@@ -292,9 +292,9 @@ EOS
     d.run(expect_emits: 1)
     events = d.events
     expected_records = [
-      { "message" => "aaa\n" },
-      { "message" => "bbb\n" },
-      { "message" => "ccc\n" }
+      { "s3_bucket" => "test_bucket", "s3_key" => "test_key", "message" => "aaa\n" },
+      { "s3_bucket" => "test_bucket", "s3_key" => "test_key","message" => "bbb\n" },
+      { "s3_bucket" => "test_bucket", "s3_key" => "test_key","message" => "ccc\n" }
     ]
     assert_equal(expected_records, events.map {|_tag, _time, record| record })
   end

--- a/test/test_in_s3.rb
+++ b/test/test_in_s3.rb
@@ -221,12 +221,82 @@ EOS
     end
     d.run(expect_emits: 1)
     events = d.events
+    assert_equal({ "message" => "aaa" }, events.first[2])
+  end
+
+  def test_one_record_with_metadata
+    setup_mocks
+    d = create_driver(CONFIG + "\ncheck_apikey_on_start false\nstore_as text\nformat none\nadd_object_metadata true\n")
+
+    s3_object = stub(Object.new)
+    s3_response = stub(Object.new)
+    s3_response.body { StringIO.new("aaa") }
+    s3_object.get { s3_response }
+    @s3_bucket.object(anything).at_least(1) { s3_object }
+
+    body = {
+      "Records" => [
+        {
+          "s3" => {
+            "object" => {
+              "key" => "test_key"
+            }
+          }
+        }
+      ]
+    }
+    message = Struct::StubMessage.new(1, 1, Yajl.dump(body))
+    @sqs_poller.get_messages(anything, anything) do |config, stats|
+      config.before_request.call(stats) if config.before_request
+      stats.request_count += 1
+      if stats.request_count >= 1
+        d.instance.instance_variable_set(:@running, false)
+      end
+      [message]
+    end
+    d.run(expect_emits: 1)
+    events = d.events
     assert_equal({ "s3_bucket" => "test_bucket", "s3_key" => "test_key", "message" => "aaa" }, events.first[2])
   end
 
   def test_one_record_url_encoded
     setup_mocks
     d = create_driver(CONFIG + "\ncheck_apikey_on_start false\nstore_as text\nformat none\n")
+
+    s3_object = stub(Object.new)
+    s3_response = stub(Object.new)
+    s3_response.body { StringIO.new("aaa") }
+    s3_object.get { s3_response }
+    @s3_bucket.object('test key').at_least(1) { s3_object }
+
+    body = {
+      "Records" => [
+        {
+          "s3" => {
+            "object" => {
+              "key" => "test+key"
+            }
+          }
+        }
+      ]
+    }
+    message = Struct::StubMessage.new(1, 1, Yajl.dump(body))
+    @sqs_poller.get_messages(anything, anything) do |config, stats|
+      config.before_request.call(stats) if config.before_request
+      stats.request_count += 1
+      if stats.request_count >= 1
+        d.instance.instance_variable_set(:@running, false)
+      end
+      [message]
+    end
+    d.run(expect_emits: 1)
+    events = d.events
+    assert_equal({ "message" => "aaa" }, events.first[2])
+  end
+
+  def test_one_record_url_encoded_with_metadata
+    setup_mocks
+    d = create_driver(CONFIG + "\ncheck_apikey_on_start false\nstore_as text\nformat none\nadd_object_metadata true")
 
     s3_object = stub(Object.new)
     s3_response = stub(Object.new)
@@ -292,9 +362,49 @@ EOS
     d.run(expect_emits: 1)
     events = d.events
     expected_records = [
+      { "message" => "aaa\n" },
+      { "message" => "bbb\n" },
+      { "message" => "ccc\n" }
+    ]
+    assert_equal(expected_records, events.map {|_tag, _time, record| record })
+  end
+
+  def test_one_record_multi_line_with_metadata
+    setup_mocks
+    d = create_driver(CONFIG + "\ncheck_apikey_on_start false\nstore_as text\nformat none\nadd_object_metadata true")
+
+    s3_object = stub(Object.new)
+    s3_response = stub(Object.new)
+    s3_response.body { StringIO.new("aaa\nbbb\nccc\n") }
+    s3_object.get { s3_response }
+    @s3_bucket.object(anything).at_least(1) { s3_object }
+
+    body = {
+      "Records" => [
+        {
+          "s3" => {
+            "object" => {
+              "key" => "test_key"
+            }
+          }
+        }
+      ]
+    }
+    message = Struct::StubMessage.new(1, 1, Yajl.dump(body))
+    @sqs_poller.get_messages(anything, anything) do |config, stats|
+      config.before_request.call(stats) if config.before_request
+      stats.request_count += 1
+      if stats.request_count >= 1
+        d.instance.instance_variable_set(:@running, false)
+      end
+      [message]
+    end
+    d.run(expect_emits: 1)
+    events = d.events
+    expected_records = [
       { "s3_bucket" => "test_bucket", "s3_key" => "test_key", "message" => "aaa\n" },
-      { "s3_bucket" => "test_bucket", "s3_key" => "test_key","message" => "bbb\n" },
-      { "s3_bucket" => "test_bucket", "s3_key" => "test_key","message" => "ccc\n" }
+      { "s3_bucket" => "test_bucket", "s3_key" => "test_key", "message" => "bbb\n" },
+      { "s3_bucket" => "test_bucket", "s3_key" => "test_key", "message" => "ccc\n" }
     ]
     assert_equal(expected_records, events.map {|_tag, _time, record| record })
   end


### PR DESCRIPTION
My use case for this is parsing logs from cloudfront and s3 that have all been dumped in a single bucket at different prefixes. Since cloudfront and s3 have different logging formats, I need a way to process the records based on what type they are. Adding the key lets me use that to retag the record using the record_transformer filter and then use that tag further down the pipeline.

I could see a use case for adding other metadata from the object to the record, but I don't need it.