### PR TITLE
Enable time_slice in s3_object_key_format even when check_object is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,8 @@ When it is false,
 Check object before creation if it exists or not. Default is true.
 
 When it is false,
-	s3_object_key_format will be %{path}%{date_slice}_%{time_slice}.%{file_extension}
-	where, time_slice will be in hhmmss format, so that each object will be unique.
+	s3_object_key_format will be %{path}%{time_slice}_%{hms_slice}.%{file_extension} by default
+	where, hms_slice will be time-slice in hhmmss format, so that each object will be unique.
 	Example object name, assuming it is created on 2016/16/11 3:30:54 PM
 		20161611_153054.txt (extension can be anything as per user's choice)
 

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -178,8 +178,8 @@ module Fluent::Plugin
         if conf.has_key?('s3_object_key_format')
           log.warn "Set 'check_object false' and s3_object_key_format is specified. Check s3_object_key_format is unique in each write. If not, existing file will be overwritten."
         else
-          log.warn "Set 'check_object false' and s3_object_key_format is not specified. Use '%{path}/%{date_slice}_%{hms_slice}.%{file_extension}' for s3_object_key_format"
-          @s3_object_key_format = "%{path}/%{date_slice}_%{hms_slice}.%{file_extension}"
+          log.warn "Set 'check_object false' and s3_object_key_format is not specified. Use '%{path}/%{time_slice}_%{hms_slice}.%{file_extension}' for s3_object_key_format"
+          @s3_object_key_format = "%{path}/%{time_slice}_%{hms_slice}.%{file_extension}"
         end
       end
 
@@ -280,7 +280,8 @@ module Fluent::Plugin
           "%{file_extension}" => @compressor.ext,
         }
         values_for_s3_object_key_post = {
-          "%{date_slice}" => time_slice,
+          "%{date_slice}" => time_slice,  # For backward compatibility
+          "%{time_slice}" => time_slice,
           "%{hms_slice}" => hms_slicer,
         }.merge!(@values_for_s3_object_chunk[chunk.unique_id])
         values_for_s3_object_key_post["%{uuid_flush}".freeze] = uuid_random if @uuid_flush_enabled


### PR DESCRIPTION
## Why
When `check_object` is false, `%{time_slice}` cannot be used in `s3_object_key_format` and `%{date_slice}` should be used instead of it.
I think this behavior is very confusing.

## What
This PR enables the usage of `%{time_slice}` in `s3_object_key_format` even when `check_object` is false.

### Before
fluent config is below.

```fluentd
<match pattern>
  @type s3

  .
  .
  .
  check_object false
  s3_object_key_format %{path}/%{time_slice}_%{hms_slice}.%{file_extension}
</match>
```

s3 object path will be `s3://.../_112020.gz`.

### After

```fluentd
<match pattern>
  @type s3

  .
  .
  .
  check_object false
  s3_object_key_format %{path}/%{time_slice}_%{hms_slice}.%{file_extension}
</match>
```

s3 object path will be `s3://.../20180713_112020.gz`.