### PR TITLE
Improve check_apikeys() performance for v0.12 branch.

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -362,7 +362,7 @@ module Fluent
     end
 
     def check_apikeys
-      @bucket.objects(:prefix => @path).first
+      @bucket.objects(:prefix => @path, :max_keys => 1).first
     rescue Aws::S3::Errors::NoSuchBucket
       # ignore NoSuchBucket Error because ensure_bucket checks it.
     rescue => e


### PR DESCRIPTION
https://github.com/fluent/fluent-plugin-s3/pull/242 to v0.12 branch.

If there are too many files under @path, it may take several tens of seconds to execute check_apikeys().

By specifying max_keys, it will be able to run in less than 1 second regardless of the number of files.

Would you please merge to v0.12 branch.

