### PR TITLE
Add endpoint support to in_s3

### DIFF
--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -64,6 +64,12 @@ module Fluent::Plugin
     config_param :s3_bucket, :string
     desc "S3 region name"
     config_param :s3_region, :string, default: ENV["AWS_REGION"] || "us-east-1"
+    desc "Use 's3_region' instead"
+    config_param :s3_endpoint, :string, default: nil
+    desc "Use 's3_region' instead"
+    config_param :sqs_endpoint, :string, default: nil
+    desc "If true, the bucket name is always left in the request URI and never moved to the host as a sub-domain"
+    config_param :force_path_style, :bool, default: false
     desc "Archive format on S3"
     config_param :store_as, :string, default: "gzip"
     desc "Check AWS key on start"
@@ -196,6 +202,8 @@ module Fluent::Plugin
     def create_s3_client
       options = setup_credentials
       options[:region] = @s3_region if @s3_region
+      options[:endpoint] = @s3_endpoint if @s3_endpoint
+      options[:force_path_style] = @force_path_style
       options[:proxy_uri] = @proxy_uri if @proxy_uri
       log.on_trace do
         options[:http_wire_trace] = true
@@ -208,6 +216,7 @@ module Fluent::Plugin
     def create_sqs_client
       options = setup_credentials
       options[:region] = @s3_region if @s3_region
+      options[:endpoint] = @sqs_endpoint if @sqs_endpoint
       log.on_trace do
         options[:http_wire_trace] = true
         options[:logger] = log

--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -98,6 +98,14 @@ module Fluent::Plugin
     def configure(conf)
       super
 
+      if @s3_endpoint && @s3_endpoint.end_with?('amazonaws.com')
+        raise Fluent::ConfigError, "s3_endpoint parameter is not supported for S3, use s3_region instead. This parameter is for S3 compatible services"
+      end
+
+      if @sqs.endpoint && @sqs.endpoint.end_with?('amazonaws.com')
+        raise Fluent::ConfigError, "sqs/endpoint parameter is not supported for SQS, use s3_region instead. This parameter is for SQS compatible services"
+      end
+
       parser_config = conf.elements("parse").first
       unless @sqs.queue_name
         raise Fluent::ConfigError, "sqs/queue_name is required"

--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -66,8 +66,6 @@ module Fluent::Plugin
     config_param :s3_region, :string, default: ENV["AWS_REGION"] || "us-east-1"
     desc "Use 's3_region' instead"
     config_param :s3_endpoint, :string, default: nil
-    desc "Use 's3_region' instead"
-    config_param :sqs_endpoint, :string, default: nil
     desc "If true, the bucket name is always left in the request URI and never moved to the host as a sub-domain"
     config_param :force_path_style, :bool, default: false
     desc "Archive format on S3"
@@ -80,6 +78,8 @@ module Fluent::Plugin
     config_section :sqs, required: true, multi: false do
       desc "SQS queue name"
       config_param :queue_name, :string, default: nil
+      desc "Use 's3_region' instead"
+      config_param :endpoint, :string, default: nil
       desc "Skip message deletion"
       config_param :skip_delete, :bool, default: false
       desc "The long polling interval."
@@ -216,7 +216,7 @@ module Fluent::Plugin
     def create_sqs_client
       options = setup_credentials
       options[:region] = @s3_region if @s3_region
-      options[:endpoint] = @sqs_endpoint if @sqs_endpoint
+      options[:endpoint] = @sqs.endpoint if @sqs.endpoint
       log.on_trace do
         options[:http_wire_trace] = true
         options[:logger] = log

--- a/test/test_in_s3.rb
+++ b/test/test_in_s3.rb
@@ -112,6 +112,40 @@ class S3InputTest < Test::Unit::TestCase
     end
   end
 
+
+  def test_s3_endpoint_with_valid_endpoint
+    d = create_driver(CONFIG + 's3_endpoint riak-cs.example.com')
+    assert_equal 'riak-cs.example.com', d.instance.s3_endpoint
+  end
+
+  data('US West (Oregon)' => 's3-us-west-2.amazonaws.com',
+       'EU (Frankfurt)' => 's3.eu-central-1.amazonaws.com',
+       'Asia Pacific (Tokyo)' => 's3-ap-northeast-1.amazonaws.com')
+  def test_s3_endpoint_with_invalid_endpoint(endpoint)
+    assert_raise(Fluent::ConfigError, "s3_endpoint parameter is not supported, use s3_region instead. This parameter is for S3 compatible services") {
+      create_driver(CONFIG + "s3_endpoint #{endpoint}")
+    }
+  end
+
+  data('US West (Oregon)' => 's3-us-west-2.amazonaws.com',
+       'EU (Frankfurt)' => 's3.eu-central-1.amazonaws.com',
+       'Asia Pacific (Tokyo)' => 's3-ap-northeast-1.amazonaws.com')
+  def test_sqs_endpoint_with_invalid_endpoint(endpoint)
+    assert_raise(Fluent::ConfigError, "sqs.endpoint parameter is not supported, use s3_region instead. This parameter is for SQS compatible services") {
+      conf = <<"EOS"
+aws_key_id test_key_id
+aws_sec_key test_sec_key
+s3_bucket test_bucket
+buffer_type memory
+<sqs>
+  queue_name test_queue
+  endpoint #{endpoint}
+</sqs>
+EOS
+      create_driver(conf)
+    }
+  end
+
   Struct.new("StubResponse", :queue_url)
   Struct.new("StubMessage", :message_id, :receipt_handle, :body)
 


### PR DESCRIPTION
I tried this plugin with locakstack for testing and checking, but did not work.
`out_s3` plugin already have parameter `s3_endpoint`, but `in_s3` plugin not.  
Thus, I just added some parameters to set the endpoint.

Configurations can be set as follows
```
<source>
  ...
  s3_endpoint http://localstack:4572
  force_path_style true
  <sqs>
    queue_name my-queue
    endpoint http://localstack:4576
  </sqs>
</source>
```

I think that it will be easier to test and check locally, if these parameters become available.