### PR TITLE
Update proxy setting for S3 input plugin

### DIFF
--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -225,6 +225,7 @@ module Fluent::Plugin
       options = setup_credentials
       options[:region] = @s3_region if @s3_region
       options[:endpoint] = @sqs.endpoint if @sqs.endpoint
+      options[:http_proxy] = @proxy_uri if @proxy_uri
       log.on_trace do
         options[:http_wire_trace] = true
         options[:logger] = log

--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -212,7 +212,7 @@ module Fluent::Plugin
       options[:region] = @s3_region if @s3_region
       options[:endpoint] = @s3_endpoint if @s3_endpoint
       options[:force_path_style] = @force_path_style
-      options[:proxy_uri] = @proxy_uri if @proxy_uri
+      options[:http_proxy] = @proxy_uri if @proxy_uri
       log.on_trace do
         options[:http_wire_trace] = true
         options[:logger] = log


### PR DESCRIPTION
According to https://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html, the proxy option name for S3 should be `http_proxy` instead of `proxy_uri`. It should fix below error

```
2018-11-14 22:35:21 +0000 [error]: #0 unexpected error error_class=ArgumentError error="invalid configuration option `:proxy_uri'"
```

Also, `http_proxy` is missing in `create_sqs_client` function