### PR TITLE
in_s3: Catch SQS poller exception and restart [retry] the poller loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,10 @@ When true, messages are not deleted after polling block. Default is false.
 
 The long polling interval. Default is 20.
 
+**sqs/retry_error_interval**
+
+Interval to retry polling SQS if polling unsuccessful, in seconds. Default is 300.
+
 ## IAM Policy
 
 The following is an example for a minimal IAM policy needed to write to an s3


### PR DESCRIPTION
The `@poller.poll(...)` block is supposed to run forever unless shutdown. 

This PR adds a retry to catch when poll throws any exception and so keeps the polling thread running.

e.g. Network issue between fluentd and AWS, would cause `.poll` to throw.