### PR TITLE
Pass chunk directly instead of chunk.metadata

### DIFF
--- a/fluent-plugin-s3.gemspec
+++ b/fluent-plugin-s3.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", [">= 0.14.2", "< 2"]
+  gem.add_dependency "fluentd", [">= 0.14.22", "< 2"]
   gem.add_dependency "aws-sdk-s3", "~> 1.0"
   gem.add_dependency "aws-sdk-sqs", "~> 1.0"
   gem.add_development_dependency "rake", ">= 0.9.2"

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -251,7 +251,7 @@ module Fluent::Plugin
           s3path = @s3_object_key_format.gsub(%r(%{[^}]+})) do |matched_key|
             values_for_s3_object_key_pre.fetch(matched_key, matched_key)
           end
-          s3path = extract_placeholders(s3path, metadata)
+          s3path = extract_placeholders(s3path, chunk)
           s3path = s3path.gsub(%r(%{[^}]+}), values_for_s3_object_key_post)
           if (i > 0) && (s3path == previous_path)
             if @overwrite
@@ -289,7 +289,7 @@ module Fluent::Plugin
         s3path = @s3_object_key_format.gsub(%r(%{[^}]+})) do |matched_key|
           values_for_s3_object_key_pre.fetch(matched_key, matched_key)
         end
-        s3path = extract_placeholders(s3path, metadata)
+        s3path = extract_placeholders(s3path, chunk)
         s3path = s3path.gsub(%r(%{[^}]+}), values_for_s3_object_key_post)
       end
 
@@ -319,7 +319,7 @@ module Fluent::Plugin
         if @s3_metadata
           put_options[:metadata] = {}
           @s3_metadata.each do |k, v|
-            put_options[:metadata][k] = extract_placeholders(v, metadata).gsub(%r(%{[^}]+}), {"%{index}" => sprintf(@index_format, i - 1)})
+            put_options[:metadata][k] = extract_placeholders(v, chunk).gsub(%r(%{[^}]+}), {"%{index}" => sprintf(@index_format, i - 1)})
           end
         end
         @bucket.object(s3path).put(put_options)


### PR DESCRIPTION
extract_placeholders should be passed `chunk` instance directly instead of `chunk.metadata`.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>