### PR TITLE
Add support for ECSCredentials to in_s3

### DIFF
--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -218,7 +218,7 @@ module Fluent::Plugin
         c = @shared_credentials
         credentials_options[:path] = c.path if c.path
         credentials_options[:profile_name] = c.profile_name if c.profile_name
-        options[:credentials] = Aws::ECSCredentials.new(credentials_options)
+        options[:credentials] = Aws::SharedCredentials.new(credentials_options)
       else
         # Use default credentials
         # See http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html

--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -209,12 +209,20 @@ module Fluent::Plugin
         credentials_options[:port] = c.port if c.port
         credentials_options[:http_open_timeout] = c.http_open_timeout if c.http_open_timeout
         credentials_options[:http_read_timeout] = c.http_read_timeout if c.http_read_timeout
-        options[:credentials] = Aws::InstanceProfileCredentials.new(credentials_options)
+        if ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
+          options[:credentials] = Aws::ECSCredentials.new(credentials_options)
+        else
+          options[:credentials] = Aws::InstanceProfileCredentials.new(credentials_options)
+        end
       when @shared_credentials
         c = @shared_credentials
         credentials_options[:path] = c.path if c.path
         credentials_options[:profile_name] = c.profile_name if c.profile_name
-        options[:credentials] = Aws::SharedCredentials.new(credentials_options)
+        if ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
+          options[:credentials] = Aws::ECSCredentials.new(credentials_options)
+        else
+          options[:credentials] = Aws::InstanceProfileCredentials.new(credentials_options)
+        end
       else
         # Use default credentials
         # See http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html

--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -218,11 +218,7 @@ module Fluent::Plugin
         c = @shared_credentials
         credentials_options[:path] = c.path if c.path
         credentials_options[:profile_name] = c.profile_name if c.profile_name
-        if ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
-          options[:credentials] = Aws::ECSCredentials.new(credentials_options)
-        else
-          options[:credentials] = Aws::InstanceProfileCredentials.new(credentials_options)
-        end
+        options[:credentials] = Aws::ECSCredentials.new(credentials_options)
       else
         # Use default credentials
         # See http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html


### PR DESCRIPTION
use ECSCredentials instead of InstanceProfileCredentials if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is set

fixes #283 