### PR TITLE
Standardize default values of s3_object_key_format

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -188,8 +188,8 @@ module Fluent::Plugin
         if conf.has_key?('s3_object_key_format')
           log.warn "Set 'check_object false' and s3_object_key_format is specified. Check s3_object_key_format is unique in each write. If not, existing file will be overwritten."
         else
-          log.warn "Set 'check_object false' and s3_object_key_format is not specified. Use '%{path}/%{time_slice}_%{hms_slice}.%{file_extension}' for s3_object_key_format"
-          @s3_object_key_format = "%{path}/%{time_slice}_%{hms_slice}.%{file_extension}"
+          log.warn "Set 'check_object false' and s3_object_key_format is not specified. Use '%{path}%{time_slice}_%{hms_slice}.%{file_extension}' for s3_object_key_format"
+          @s3_object_key_format = "%{path}%{time_slice}_%{hms_slice}.%{file_extension}"
         end
       end
 

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -297,9 +297,9 @@ EOC
     setup_mocks_hardened_policy
     s3_local_file_path = "/tmp/s3-test.txt"
     # @s3_object_key_format will be hard_coded with timestamp only,
-    # as in this case, it will not check for object existence, not even bucker existence
-    # check_bukcet and check_object both of this config parameter should be false
-    # @s3_object_key_format = "%{path}/%{time_slice}_%{hms_slice}.%{file_extension}"
+    # as in this case, it will not check for object existence, not even bucket existence
+    # check_bucket and check_object: both of these config parameters should be false
+    # @s3_object_key_format = "%{path}%{time_slice}_%{hms_slice}.%{file_extension}"
     setup_s3_object_mocks_hardened_policy()
 
     # We must use TimeSlicedOutputTestDriver instead of BufferedOutputTestDriver,


### PR DESCRIPTION
Regardless of whether check_object is set to true or false the
path-configuration should expect a trailing slash for both of the cases
instead of behaving differently.

Signed-off-by: Markus Nilsson <markus.nilsson@yubico.com>