### PR TITLE
update S3 SDK + fix region access in tests

### DIFF
--- a/fluent-plugin-s3.gemspec
+++ b/fluent-plugin-s3.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "fluentd", [">= 0.14.22", "< 2"]
-  gem.add_dependency "aws-sdk-s3", "~> 1.0"
-  gem.add_dependency "aws-sdk-sqs", "~> 1.0"
+  gem.add_dependency "aws-sdk-s3", "~> 1.60"
+  gem.add_dependency "aws-sdk-sqs", "~> 1.23"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", ">= 3.0.8"
   gem.add_development_dependency "test-unit-rr", ">= 1.0.3"

--- a/test/test_in_s3.rb
+++ b/test/test_in_s3.rb
@@ -11,6 +11,7 @@ require 'fluent/plugin/in_s3'
 require 'test/unit/rr'
 require 'zlib'
 require 'fileutils'
+require 'ostruct'
 
 include Fluent::Test::Helpers
 
@@ -152,6 +153,7 @@ EOS
 
   def setup_mocks
     @s3_client = stub(Aws::S3::Client.new(stub_responses: true))
+    stub(@s3_client).config { OpenStruct.new({region: "us-east-1"}) }
     mock(Aws::S3::Client).new(anything).at_least(0) { @s3_client }
     @s3_resource = mock(Aws::S3::Resource.new(client: @s3_client))
     mock(Aws::S3::Resource).new(client: @s3_client) { @s3_resource }

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -10,6 +10,7 @@ require 'zlib'
 require 'fileutils'
 require 'timecop'
 require 'uuidtools'
+require 'ostruct'
 
 include Fluent::Test::Helpers
 
@@ -427,6 +428,7 @@ EOC
 
   def setup_mocks(exists_return = false)
     @s3_client = stub(Aws::S3::Client.new(stub_responses: true))
+    stub(@s3_client).config { OpenStruct.new({region: "us-east-1"}) }
     # aws-sdk-s3 calls Client#put_object inside Object#put
     mock(@s3_client).put_object(anything).at_least(0) { MockResponse.new({}) }
     mock(Aws::S3::Client).new(anything).at_least(0) { @s3_client }
@@ -464,6 +466,7 @@ EOC
 
   def setup_mocks_hardened_policy()
     @s3_client = stub(Aws::S3::Client.new(:stub_responses => true))
+    stub(@s3_client).config { OpenStruct.new({region: "us-east-1"}) }
     mock(@s3_client).put_object(anything).at_least(0) { MockResponse.new({}) }
     mock(Aws::S3::Client).new(anything).at_least(0) { @s3_client }
     @s3_resource = mock(Aws::S3::Resource.new(:client => @s3_client))


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

This allows us to use the most recent AWS S3 and STS Ruby SDKs and fixes the build as well.

Fixes: https://github.com/fluent/fluent-plugin-s3/issues/301