### PR TITLE
Add SNS event support

### DIFF
--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -104,6 +104,8 @@ module Fluent::Plugin
       config_param :wait_time_seconds, :integer, default: 20
       desc "Polling error retry interval."
       config_param :retry_error_interval, :integer, default: 300
+      desc "Assume messages as SNS notifications"
+      config_param :assume_sns, :bool, default: false
     end
 
     desc "Tag string"
@@ -182,6 +184,10 @@ module Fluent::Plugin
           begin
             body = Yajl.load(message.body)
             log.debug(body)
+            if @assume_sns
+              next unless body["Message"]
+              body = Yajl.load(body["Message"])
+            end
             next unless body["Records"] # skip test queue
 
             process(body)


### PR DESCRIPTION
Add support for SQS messages arriving via SNS. This is commonly used to
fan out S3 events.

Because SNS wraps the messages, we need to dive one layer deeper into
the SQS body.

https://aws.amazon.com/blogs/compute/fanout-s3-event-notifications-to-multiple-endpoints/