### PR TITLE
Skip compression when buffer already compressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,10 @@ log"}', then contents are
 
 You can change key name by "message_key" option.
 
+**recompress**
+
+Execute compression again even when buffer chunk is already compressed. Default is false.
+
 **auto_create_bucket**
 
 Create S3 bucket if it does not exists. Default is true.


### PR DESCRIPTION
It works if buffer is gzipped and output format is gzip.

Also, added *recompress* parameter to compress even when buffer is
compressed, this means that buffer is first decompressed and then
compression is applied again.

I am complete Ruby novice, so, feel free to close this PR if it does not meet your coding standards or is otherwise badly written.
OTOH it would be nice to have such feature to avoid wasting CPU when buffer is already gzipped and output is also gzip.

