### PR TITLE
Support S3 Dual-Stack Endpoints in output plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ See also AWS article: [Working with Regions](https://aws.amazon.com/blogs/develo
 
 Enable [S3 Transfer Acceleration](https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html) for uploads. **IMPORTANT**: For this to work, you must first enable this feature on your destination S3 bucket.
 
+**enable_dual_stack**
+
+Enable [Amazon S3 Dual-Stack Endpoints](https://docs.aws.amazon.com/AmazonS3/latest/dev/dual-stack-endpoints.html) for uploads. Will make it possible to use either IPv4 or IPv6 when connecting to S3.
+
 **use_bundled_cert**
 
 For cases where the default SSL certificate is unavailable (e.g. Windows), you can set this option to true in order to use the AWS SDK bundled certificate. Default is false.

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -84,6 +84,8 @@ module Fluent::Plugin
     config_param :s3_endpoint, :string, default: nil
     desc "If true, S3 Transfer Acceleration will be enabled for uploads. IMPORTANT: You must first enable this feature on your destination S3 bucket"
     config_param :enable_transfer_acceleration, :bool, default: false
+    desc "If true, use Amazon S3 Dual-Stack Endpoints. Will make it possible to use either IPv4 or IPv6 when connecting to S3."
+    config_param :enable_dual_stack, :bool, default: false
     desc "If false, the certificate of endpoint will not be verified"
     config_param :ssl_verify_peer, :bool, :default => true
     desc "The format of S3 object keys"
@@ -223,6 +225,7 @@ module Fluent::Plugin
       options[:region] = @s3_region if @s3_region
       options[:endpoint] = @s3_endpoint if @s3_endpoint
       options[:use_accelerate_endpoint] = @enable_transfer_acceleration
+      options[:use_dualstack_endpoint] = @enable_dual_stack
       options[:http_proxy] = @proxy_uri if @proxy_uri
       options[:force_path_style] = @force_path_style
       options[:compute_checksums] = @compute_checksums unless @compute_checksums.nil?


### PR DESCRIPTION
Only doing this for the output plugin, since there are no
corresponding SQS Dual-Stack Endpoints, making the change less
meaningful for the input plugin.

Signed-off-by: Andreas Olsson <andreas@arrakis.se>