### PR TITLE
remove s3_endpoint check for amazonaws.com domain.

### DIFF
--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -118,14 +118,6 @@ module Fluent::Plugin
     def configure(conf)
       super
 
-      if @s3_endpoint && @s3_endpoint.end_with?('amazonaws.com')
-        raise Fluent::ConfigError, "s3_endpoint parameter is not supported for S3, use s3_region instead. This parameter is for S3 compatible services"
-      end
-
-      if @sqs.endpoint && @sqs.endpoint.end_with?('amazonaws.com')
-        raise Fluent::ConfigError, "sqs/endpoint parameter is not supported for SQS, use s3_region instead. This parameter is for SQS compatible services"
-      end
-
       parser_config = conf.elements("parse").first
       unless @sqs.queue_name
         raise Fluent::ConfigError, "sqs/queue_name is required"

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -171,10 +171,6 @@ module Fluent::Plugin
 
       Aws.use_bundled_cert! if @use_bundled_cert
 
-      if @s3_endpoint && @s3_endpoint.end_with?('amazonaws.com')
-        raise Fluent::ConfigError, "s3_endpoint parameter is not supported for S3, use s3_region instead. This parameter is for S3 compatible services"
-      end
-
       begin
         buffer_type = @buffer_config[:@type]
         @compressor = COMPRESSOR_REGISTRY.lookup(@store_as).new(buffer_type: buffer_type, log: log)

--- a/test/test_in_s3.rb
+++ b/test/test_in_s3.rb
@@ -120,34 +120,6 @@ class S3InputTest < Test::Unit::TestCase
     assert_equal 'riak-cs.example.com', d.instance.s3_endpoint
   end
 
-  data('US West (Oregon)' => 's3-us-west-2.amazonaws.com',
-       'EU (Frankfurt)' => 's3.eu-central-1.amazonaws.com',
-       'Asia Pacific (Tokyo)' => 's3-ap-northeast-1.amazonaws.com')
-  def test_s3_endpoint_with_invalid_endpoint(endpoint)
-    assert_raise(Fluent::ConfigError, "s3_endpoint parameter is not supported, use s3_region instead. This parameter is for S3 compatible services") {
-      create_driver(CONFIG + "s3_endpoint #{endpoint}")
-    }
-  end
-
-  data('US West (Oregon)' => 's3-us-west-2.amazonaws.com',
-       'EU (Frankfurt)' => 's3.eu-central-1.amazonaws.com',
-       'Asia Pacific (Tokyo)' => 's3-ap-northeast-1.amazonaws.com')
-  def test_sqs_endpoint_with_invalid_endpoint(endpoint)
-    assert_raise(Fluent::ConfigError, "sqs.endpoint parameter is not supported, use s3_region instead. This parameter is for SQS compatible services") {
-      conf = <<"EOS"
-aws_key_id test_key_id
-aws_sec_key test_sec_key
-s3_bucket test_bucket
-buffer_type memory
-<sqs>
-  queue_name test_queue
-  endpoint #{endpoint}
-</sqs>
-EOS
-      create_driver(conf)
-    }
-  end
-
   Struct.new("StubResponse", :queue_url)
   Struct.new("StubMessage", :message_id, :receipt_handle, :body)
 

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -73,15 +73,6 @@ class S3OutputTest < Test::Unit::TestCase
     assert_equal 'riak-cs.example.com', d.instance.s3_endpoint
   end
 
-  data('US West (Oregon)' => 's3-us-west-2.amazonaws.com',
-       'EU (Frankfurt)' => 's3.eu-central-1.amazonaws.com',
-       'Asia Pacific (Tokyo)' => 's3-ap-northeast-1.amazonaws.com')
-  def test_s3_endpoint_with_invalid_endpoint(endpoint)
-    assert_raise(Fluent::ConfigError, "s3_endpoint parameter is not supported, use s3_region instead. This parameter is for S3 compatible services") {
-      create_driver(CONFIG + "s3_endpoint #{endpoint}")
-    }
-  end
-
   def test_configure_with_mime_type_json
     conf = CONFIG.clone
     conf << "\nstore_as json\n"


### PR DESCRIPTION
Multiple endpoints may exist, notably for FIPS S3.

The FIPS SQS endpoint is not different from the usual one, but it's
removed for consistency.

https://github.com/fluent/fluent-plugin-s3/issues/331