### PR TITLE
fips s3_endpoint override is valid

### DIFF
--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -118,11 +118,11 @@ module Fluent::Plugin
     def configure(conf)
       super
 
-      if @s3_endpoint && @s3_endpoint.end_with?('amazonaws.com')
+      if @s3_endpoint && (@s3_endpoint.end_with?('amazonaws.com') && !['fips', 'gov'].any? { |e| @s3_endpoint.include?(e) })
         raise Fluent::ConfigError, "s3_endpoint parameter is not supported for S3, use s3_region instead. This parameter is for S3 compatible services"
       end
 
-      if @sqs.endpoint && @sqs.endpoint.end_with?('amazonaws.com')
+      if @sqs_endpoint && (@sqs_endpoint.end_with?('amazonaws.com') && !['fips', 'gov'].any? { |e| @sqs_endpoint.include?(e) })
         raise Fluent::ConfigError, "sqs/endpoint parameter is not supported for SQS, use s3_region instead. This parameter is for SQS compatible services"
       end
 

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -171,7 +171,7 @@ module Fluent::Plugin
 
       Aws.use_bundled_cert! if @use_bundled_cert
 
-      if @s3_endpoint && @s3_endpoint.end_with?('amazonaws.com')
+      if @s3_endpoint && (@s3_endpoint.end_with?('amazonaws.com') && !['fips', 'gov'].any? { |e| @s3_endpoint.include?(e) })
         raise Fluent::ConfigError, "s3_endpoint parameter is not supported for S3, use s3_region instead. This parameter is for S3 compatible services"
       end
 


### PR DESCRIPTION
Covers #331 - if we have an endpoint with `fips`, this is
acceptable, but otherwise we should not use `s3_endpoint` or `sqs_endpoint`
with the `amazonaws.com` domain

Signed-off-by: Matthew Lesko <mattlesko.work@gmail.com>