### PR TITLE
simpify gems, by replace uuidtools with securerandom, given the requirement is ruby >= 1.9 already

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "http://rubygems.org"
 
-gem 'uuidtools'
-
 gemspec

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ E.g., "logs/" in the example configuration above.
 time-slice in text that are formatted with **time_slice_format**.
 * %{index} is the sequential number starts from 0, increments when multiple files are uploaded to S3 in the same time slice.
 * %{file_extension} depends on **store_as** parameter.
-* %{uuid_flush} a uuid that is replaced everytime the buffer will be flushed. If you want to use this placeholder, install `uuidtools` gem first.
+* %{uuid_flush} a uuid that is replaced everytime the buffer will be flushed.
 * %{hostname} is replaced with `Socket.gethostname` result.
 * %{hex_random} a random hex string that is replaced for each buffer chunk, not
 assured to be unique. This is used to follow a way of performance tuning, `Add

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -5,6 +5,7 @@ require 'aws-sdk-s3'
 require 'zlib'
 require 'time'
 require 'tempfile'
+require 'securerandom'
 
 module Fluent::Plugin
   class S3Output < Output
@@ -384,7 +385,7 @@ module Fluent::Plugin
     end
 
     def uuid_random
-      ::UUIDTools::UUID.random_create.to_s
+      SecureRandom.uuid
     end
 
     # This is stolen from Fluentd
@@ -441,17 +442,6 @@ module Fluent::Plugin
       }
 
       if @s3_object_key_format.include?('%{uuid_flush}')
-        # test uuidtools works or not
-        begin
-          require 'uuidtools'
-        rescue LoadError
-          raise Fluent::ConfigError, "uuidtools gem not found. Install uuidtools gem first"
-        end
-        begin
-          uuid_random
-        rescue => e
-          raise Fluent::ConfigError, "Generating uuid doesn't work. Can't use %{uuid_flush} on this environment. #{e}"
-        end
         @uuid_flush_enabled = true
       end
 

--- a/test/test_out_s3.rb
+++ b/test/test_out_s3.rb
@@ -9,7 +9,6 @@ require 'test/unit/rr'
 require 'zlib'
 require 'fileutils'
 require 'timecop'
-require 'uuidtools'
 require 'ostruct'
 
 include Fluent::Test::Helpers
@@ -349,17 +348,11 @@ EOC
 
   def test_write_with_custom_s3_object_key_format_containing_uuid_flush_placeholder
 
-    begin
-      require 'uuidtools'
-    rescue LoadError
-      pend("uuidtools not found. skip this test")
-    end
-
     # Partial mock the S3Bucket, not to make an actual connection to Amazon S3
     setup_mocks(true)
 
     uuid = "5755e23f-9b54-42d8-8818-2ea38c6f279e"
-    stub(::UUIDTools::UUID).random_create{ uuid }
+    stub(::SecureRandom).uuid{ uuid }
 
     s3_local_file_path = "/tmp/s3-test.txt"
     s3path = "log/events/ts=20110102-13/events_0-#{uuid}.gz"


### PR DESCRIPTION
fix #341 