### PR TITLE
Use IAM API credentials when assuming a role. Fixes #330

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ gemfile:
 branches:
   only:
     - master
+    - test-fix
 
 before_install: gem update bundler
 script: bundle exec rake test

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -473,11 +473,10 @@ module Fluent::Plugin
       options = {}
       credentials_options = {}
       case
-      when @aws_key_id && @aws_sec_key
-        options[:access_key_id] = @aws_key_id
-        options[:secret_access_key] = @aws_sec_key
       when @assume_role_credentials
         c = @assume_role_credentials
+        iam_user_credentials = @aws_key_id && @aws_sec_key ? Aws::Credentials.new(@aws_key_id, @aws_sec_key) : nil
+        region = c.sts_region || @s3_region
         credentials_options[:role_arn] = c.role_arn
         credentials_options[:role_session_name] = c.role_session_name
         credentials_options[:policy] = c.policy if c.policy
@@ -486,21 +485,19 @@ module Fluent::Plugin
         credentials_options[:sts_endpoint_url] = c.sts_endpoint_url if c.sts_endpoint_url
         credentials_options[:sts_http_proxy] = c.sts_http_proxy if c.sts_http_proxy
         if c.sts_http_proxy && c.sts_endpoint_url
-          credentials_options[:client] = Aws::STS::Client.new(http_proxy: c.sts_http_proxy, endpoint: c.sts_endpoint_url)
-        elsif @region && c.sts_http_proxy
-          credentials_options[:client] = Aws::STS::Client.new(region: @region, http_proxy: c.sts_http_proxy)
-        elsif @region && c.sts_endpoint_url
-          credentials_options[:client] = Aws::STS::Client.new(region: @region, endpoint: c.sts_endpoint_url)
+          credentials_options[:client] = Aws::STS::Client.new(region: region, http_proxy: c.sts_http_proxy, endpoint: c.sts_endpoint_url, credentials: iam_user_credentials)
         elsif c.sts_http_proxy
-          credentials_options[:client] = Aws::STS::Client.new(http_proxy: c.sts_http_proxy)
+          credentials_options[:client] = Aws::STS::Client.new(region: region, http_proxy: c.sts_http_proxy, credentials: iam_user_credentials)
         elsif c.sts_endpoint_url
-          credentials_options[:client] = Aws::STS::Client.new(endpoint: c.sts_endpoint_url)
-        elsif c.sts_region
-          credentials_options[:client] = Aws::STS::Client.new(region: c.sts_region)
-        elsif @s3_region
-          credentials_options[:client] = Aws::STS::Client.new(region: @s3_region)
+          credentials_options[:client] = Aws::STS::Client.new(region: region, endpoint: c.sts_endpoint_url, credentials: iam_user_credentials)
+        else
+          credentials_options[:client] = Aws::STS::Client.new(region: region, credentials: iam_user_credentials)
         end
+
         options[:credentials] = Aws::AssumeRoleCredentials.new(credentials_options)
+      when @aws_key_id && @aws_sec_key
+        options[:access_key_id] = @aws_key_id
+        options[:secret_access_key] = @aws_sec_key
       when @web_identity_credentials
         c = @web_identity_credentials
         credentials_options[:role_arn] = c.role_arn


### PR DESCRIPTION
Hi,
Disclaimer:  I'm not a ruby developer.

The PR fixes the issue mentioned in #330. I had added a couple of unit tests to check the existing functionality and noticed a few strange things e.g. I couldn't find the place in which @region gets initialized, some of conditions are probably redundant (?).
I would appreaciate a thorough review :)
Thanks in advance!