### PR TITLE
Enable multi process workers support

### DIFF
--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -139,6 +139,10 @@ module Fluent::Plugin
       @parser = parser_create(conf: parser_config, default_type: DEFAULT_PARSE_TYPE)
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     def start
       super
 


### PR DESCRIPTION
Enables Fluentd multi process workers support for the input plugin.

Concurrency safety is enforced by the SQS queue, so no additional code is required.

This is specially advantageous for high BDP connections (high latency, high throughput), because it allows multiple simultaneous download streams from S3.