### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install: gem update bundler
 script: bundle exec rake test
 
 sudo: false
+cache: bundler
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Would be interested to know why bundler caching of Travis hasn't been enabled in this repository. Thank you.