### PR TITLE
Don't raise error when s3_endpoint is used for VPC endpoint

### DIFF
--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -115,10 +115,15 @@ module Fluent::Plugin
 
     attr_reader :bucket
 
+    def reject_s3_endpoint?
+      @s3_endpoint && !@s3_endpoint.end_with?('vpce.amazonaws.com') &&
+        @s3_endpoint.end_with?('amazonaws.com') && !['fips', 'gov'].any? { |e| @s3_endpoint.include?(e) }
+    end
+
     def configure(conf)
       super
 
-      if @s3_endpoint && (@s3_endpoint.end_with?('amazonaws.com') && !['fips', 'gov'].any? { |e| @s3_endpoint.include?(e) })
+      if reject_s3_endpoint?
         raise Fluent::ConfigError, "s3_endpoint parameter is not supported for S3, use s3_region instead. This parameter is for S3 compatible services"
       end
 

--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -173,6 +173,11 @@ module Fluent::Plugin
 
     MAX_HEX_RANDOM_LENGTH = 16
 
+    def reject_s3_endpoint?
+      @s3_endpoint && !@s3_endpoint.end_with?('vpce.amazonaws.com') &&
+        @s3_endpoint.end_with?('amazonaws.com') && !['fips', 'gov'].any? { |e| @s3_endpoint.include?(e) }
+    end
+
     def configure(conf)
       compat_parameters_convert(conf, :buffer, :formatter, :inject)
 
@@ -180,7 +185,7 @@ module Fluent::Plugin
 
       Aws.use_bundled_cert! if @use_bundled_cert
 
-      if @s3_endpoint && (@s3_endpoint.end_with?('amazonaws.com') && !['fips', 'gov'].any? { |e| @s3_endpoint.include?(e) })
+      if reject_s3_endpoint?
         raise Fluent::ConfigError, "s3_endpoint parameter is not supported for S3, use s3_region instead. This parameter is for S3 compatible services"
       end
 

--- a/test/test_in_s3.rb
+++ b/test/test_in_s3.rb
@@ -115,14 +115,19 @@ class S3InputTest < Test::Unit::TestCase
   end
 
 
-  def test_s3_endpoint_with_valid_endpoint
-    d = create_driver(CONFIG + 's3_endpoint riak-cs.example.com')
-    assert_equal 'riak-cs.example.com', d.instance.s3_endpoint
+  data('Normal endpoint' => 'riak-cs.example.com',
+       'VPCE endpoint' => 'vpce.amazonaws.com',
+       'FIPS endpoint' => 'fips.xxx.amazonaws.com',
+       'GOV endpoint' => 'gov.xxx.amazonaws.com')
+  def test_s3_endpoint_with_valid_endpoint(endpoint)
+    d = create_driver(CONFIG + "s3_endpoint #{endpoint}")
+    assert_equal endpoint, d.instance.s3_endpoint
   end
 
   data('US West (Oregon)' => 's3-us-west-2.amazonaws.com',
        'EU (Frankfurt)' => 's3.eu-central-1.amazonaws.com',
-       'Asia Pacific (Tokyo)' => 's3-ap-northeast-1.amazonaws.com')
+       'Asia Pacific (Tokyo)' => 's3-ap-northeast-1.amazonaws.com',
+       'Invalid VPCE' => 'vpce.xxx.amazonaws.com')
   def test_s3_endpoint_with_invalid_endpoint(endpoint)
     assert_raise(Fluent::ConfigError, "s3_endpoint parameter is not supported, use s3_region instead. This parameter is for S3 compatible services") {
       create_driver(CONFIG + "s3_endpoint #{endpoint}")


### PR DESCRIPTION
Usually, using s3_region is recommended, but when accessing
s3 via VPC, it should not raise an error.

VPC endpoint(For example via private link) is assigned to
xxx.vpce.amazonaws.com, so it should be added as an exceptional case.

See https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html

Closes: #382
