### PR TITLE
Fix a broken test

### DIFF
--- a/test/test_in_s3.rb
+++ b/test/test_in_s3.rb
@@ -84,7 +84,7 @@ class S3InputTest < Test::Unit::TestCase
 
     def test_unknown_store_as
       config = CONFIG + "\nstore_as unknown"
-      assert_raise(Fluent::ConfigError) do
+      assert_raise(Fluent::NotFoundPluginError) do
         create_driver(config)
       end
     end


### PR DESCRIPTION
Fluent::NotFoundPluginError is instroduced as of fluentd v1.14.5

Signed-off-by: Takuro Ashie <ashie@clear-code.com>