### PR TITLE
Fix a typo in IAM Policy section description

### DIFF
--- a/docs/howto.md
+++ b/docs/howto.md
@@ -7,7 +7,7 @@ downstream processors to better identify the source of a given record.
 
 # IAM Policy
 
-The following is an example for a IAM policy needed to write to an s3 bucket (matches my-s3bucket/logs, my-s3bucket-test, etc.).
+The following is an example for a IAM policy needed to write to an s3 bucket (matches my-s3bucket/logs, my-s3bucket/test, etc.).
 
     {
       "Version": "2012-10-17",


### PR DESCRIPTION
## Context

I am currently working with the S3 plugin and noticed a typo in the description of the IAM policy section. I thought I would fix it while I am at it.

## Nature of change

In the example we can see:

```
arn:aws:s3:::my-s3bucket/*
```
This won't match `my-s3bucket-test` but rather `my-s3bucket/test`.

