### PR TITLE
Update documentation in the instance_profile_credentials section

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -126,7 +126,7 @@ See also:
 
 ### retries
 
-Number of times to retry when retrieving credentials. Default is 5.
+Number of times to retry when retrieving credentials. Default is nil.
 
 ### ip_address
 


### PR DESCRIPTION
I asked a question on Discussion (ref: https://github.com/fluent/fluentd/discussions/4236)  the other day, and after examining the commit log I found the following


Although aws_iam_retries is already deprecated, I found the following commit in the commit log for this line.

> config_param :aws_iam_retries, :integer, default: nil, deprecated: "Use 'instance_profile_credentials' instead."

ref: https://github.com/fluent/fluent-plugin-s3/blame/master/lib/fluent/plugin/out_s3.rb#L87

commit: https://github.com/fluent/fluent-plugin-s3/commit/11e8ad76a38d59177bf2ce1435c5bdcdb7f16e67

I thought the above commit was omitting an update to the Document.