### PR TITLE
dependency: remove zstd-ruby

### DIFF
--- a/fluent-plugin-s3.gemspec
+++ b/fluent-plugin-s3.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "fluentd", [">= 0.14.22", "< 2"]
   gem.add_dependency "aws-sdk-s3", "~> 1.60"
   gem.add_dependency "aws-sdk-sqs", "~> 1.23"
-  gem.add_dependency 'zstd-ruby'
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", ">= 3.0.8"
   gem.add_development_dependency "test-unit-rr", ">= 1.0.3"
@@ -27,4 +26,5 @@ Gem::Specification.new do |gem|
   # aws-sdk-core requires one of ox, oga, libxml, nokogiri or rexml,
   # and rexml is no longer default gem as of Ruby 3.0.
   gem.add_development_dependency "rexml"
+  gem.add_development_dependency "zstd-ruby"
 end

--- a/lib/fluent/plugin/s3_compressor_zstd.rb
+++ b/lib/fluent/plugin/s3_compressor_zstd.rb
@@ -1,5 +1,3 @@
-require 'zstd-ruby'
-
 module Fluent::Plugin
   class S3Output
     class ZstdCompressor < Compressor
@@ -8,6 +6,14 @@ module Fluent::Plugin
       config_section :compress, param_name: :compress_config, init: true, multi: false do
         desc "Compression level for zstd (1-22)"
         config_param :level, :integer, default: 3
+      end
+
+      def initialize(opts = {})
+        super
+        require 'zstd-ruby'
+      rescue LoadError => e
+        log.error "failed to load zstd-ruby gem. You need to manually install 'zstd-ruby' gem to use 'zstd'.", error: e.message
+        raise Fluent::ConfigError, "failed to load 'zstd-ruby' gem"
       end
 
       def ext


### PR DESCRIPTION
* Fix #444

Remove `zstd-ruby` from the dependencies.
We need to manually install `zstd-ruby` to use
`zstd` compression.

`zstd-ruby` gem needs to build native extensions.
It is not desirable to require a build environment for this optional feature.