### PR TITLE
out_s3: add debug log for when completed to write chunk

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -378,6 +378,8 @@ module Fluent::Plugin
         end
         @bucket.object(s3path).put(put_options)
 
+        log.debug "out_s3: completed to write chunk #{dump_unique_id_hex(chunk.unique_id)} with metadata #{chunk.metadata} to s3://#{@s3_bucket}/#{s3path}"
+
         @values_for_s3_object_chunk.delete(chunk.unique_id)
 
         if @warn_for_delay


### PR DESCRIPTION
Fix #414

This patch will add debug log for when completed to write chunk to S3.