### PR TITLE
out_s3: add log to output unexpected error of Tempfile#close

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -388,7 +388,11 @@ module Fluent::Plugin
           end
         end
       ensure
-        tmp.close(true) rescue nil
+        begin
+          tmp.close(true)
+        rescue => e
+          log.info "out_s3: Tempfile#close caused unexpected error", error: e
+        end
       end
     end
 


### PR DESCRIPTION
It is difficult to take any action deal with as there was no output if Tempfile#close caused unexpected error. So, this patch will add a log to know that an error has occurred in Tempfile#close.

Related to #416