### PR TITLE
in_s3: allow duplicate keys in JSON parser

### DIFF
--- a/lib/fluent/plugin/in_s3.rb
+++ b/lib/fluent/plugin/in_s3.rb
@@ -213,7 +213,7 @@ module Fluent::Plugin
       begin
         @poller.poll(options) do |message|
           begin
-            body = JSON.parse(message.body)
+            body = JSON.parse(message.body, allow_duplicate_key: true)
             log.debug(body)
             next unless is_valid_queue(body) # skip test queue
             if @match_regexp


### PR DESCRIPTION
The json gem emits a deprecation warning for duplicate keys in JSON objects and will raise `JSON::ParserError` in json 3.0 unless `allow_duplicate_key: true` is specified.

The plugin has historically accepted duplicate keys silently (last value wins). To preserve this behavior uniformly regardless of the json gem version, this passes `allow_duplicate_key: true` to `JSON.parse`.